### PR TITLE
Send x5c claims during Certificate authentication

### DIFF
--- a/MSStore.API/SubmissionClient.cs
+++ b/MSStore.API/SubmissionClient.cs
@@ -159,7 +159,7 @@ namespace MSStore.API
             ILogger? logger = null,
             CancellationToken ct = default)
         {
-            return GetClientCredentialAccessTokenAsync(tenantId, clientId, (builder) => builder.WithCertificate(certificate), scope, logger, ct);
+            return GetClientCredentialAccessTokenAsync(tenantId, clientId, (builder) => builder.WithCertificate(certificate, true), scope, logger, ct);
         }
 
         private static async Task<AuthenticationResult> GetClientCredentialAccessTokenAsync(


### PR DESCRIPTION
This allows the use of preauthorized "trusted subjects".

> Specifies if the x5c claim (public key of the certificate) should be sent to the STS. Sending the x5c enables application developers to achieve easy certificate rollover in Azure AD: this method will send the public certificate to Azure AD along with the token request, so that Azure AD can use it to validate the subject name based on a trusted issuer policy. 