### PR TITLE
list: escape markup in app table

### DIFF
--- a/MSStore.CLI/Commands/Apps/ListCommand.cs
+++ b/MSStore.CLI/Commands/Apps/ListCommand.cs
@@ -64,9 +64,9 @@ namespace MSStore.CLI.Commands.Apps
                             {
                                 table.AddRow(
                                     i.ToString(CultureInfo.InvariantCulture),
-                                    $"[bold u]{p.Id}[/]",
-                                    $"[bold u]{p.PrimaryName}[/]",
-                                    $"[bold u]{p.PackageIdentityName}[/]");
+                                    $"[bold u]{p.Id.EscapeMarkup()}[/]",
+                                    $"[bold u]{p.PrimaryName.EscapeMarkup()}[/]",
+                                    $"[bold u]{p.PackageIdentityName.EscapeMarkup()}[/]");
                                 i++;
                             }
 


### PR DESCRIPTION
Microsoft has an app with [Deleted] in the name; this explodes Spectre