### PR TITLE
Fix PriceId when using an advanced pricing model

### DIFF
--- a/MSStore.CLI/Helpers/IStorePackagedAPIExtensions.cs
+++ b/MSStore.CLI/Helpers/IStorePackagedAPIExtensions.cs
@@ -489,6 +489,11 @@ namespace MSStore.CLI.Helpers
             }
 
             DevCenterSubmission? devCenterSubmission = submission as DevCenterSubmission;
+
+            if (devCenterSubmission.Pricing.IsAdvancedPricingModel) {
+                devCenterSubmission.Pricing.PriceId = null;
+            }
+
             DevCenterFlightSubmission? devCenterFlightSubmission = submission as DevCenterFlightSubmission;
             if ((devCenterSubmission != null && devCenterSubmission.ApplicationPackages == null) ||
                 (devCenterFlightSubmission != null && devCenterFlightSubmission.FlightPackages == null))

--- a/MSStore.CLI/Helpers/IStorePackagedAPIExtensions.cs
+++ b/MSStore.CLI/Helpers/IStorePackagedAPIExtensions.cs
@@ -489,12 +489,13 @@ namespace MSStore.CLI.Helpers
             }
 
             DevCenterSubmission? devCenterSubmission = submission as DevCenterSubmission;
+            DevCenterFlightSubmission? devCenterFlightSubmission = submission as DevCenterFlightSubmission;
 
-            if (devCenterSubmission.Pricing.IsAdvancedPricingModel) {
+            if (devCenterSubmission?.Pricing != null && devCenterSubmission.Pricing.IsAdvancedPricingModel)
+            {
                 devCenterSubmission.Pricing.PriceId = null;
             }
 
-            DevCenterFlightSubmission? devCenterFlightSubmission = submission as DevCenterFlightSubmission;
             if ((devCenterSubmission != null && devCenterSubmission.ApplicationPackages == null) ||
                 (devCenterFlightSubmission != null && devCenterFlightSubmission.FlightPackages == null))
             {


### PR DESCRIPTION
The API returns a Pricing.PriceId of 'Base' by default for a new submission when using an advanced pricing model.
However, if the client then updates that submission and passes along the 'Base' id the API will complain as detailed in #66.

Therefore, it is necessary to manually set the Pricing.PriceId to null in this case.

Closes #66