### PR TITLE
feat: added option for specifying upload timeout in seconds

### DIFF
--- a/MSStore.CLI.UnitTests/BaseCommandLineTest.cs
+++ b/MSStore.CLI.UnitTests/BaseCommandLineTest.cs
@@ -203,7 +203,7 @@ namespace MSStore.CLI.UnitTests
 
             var azureBlobManagerMock = new Mock<IAzureBlobManager>();
             azureBlobManagerMock
-                .Setup(x => x.UploadFileAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<IProgress<double>>(), It.IsAny<CancellationToken>()))
+                .Setup(x => x.UploadFileAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<IProgress<double>>(), It.IsAny<long>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(string.Empty);
 
             var fileDownloader = new Mock<IFileDownloader>();

--- a/MSStore.CLI/Commands/InitCommand.cs
+++ b/MSStore.CLI/Commands/InitCommand.cs
@@ -128,6 +128,7 @@ namespace MSStore.CLI.Commands
             Options.Add(ArchOption);
             Options.Add(VersionOption);
             Options.Add(PublishCommand.PackageRolloutPercentageOption);
+            Options.Add(PublishCommand.UploadTimeoutOption);
         }
 
         public class Handler(
@@ -164,6 +165,7 @@ namespace MSStore.CLI.Commands
                 var flightId = parseResult.GetValue(PublishCommand.FlightIdOption);
                 var version = parseResult.GetValue(VersionOption);
                 var packageRolloutPercentage = parseResult.GetValue(PublishCommand.PackageRolloutPercentageOption);
+                var uploadTimeout = parseResult.GetValue(PublishCommand.UploadTimeoutOption);
                 var output = parseResult.GetValue(OutputOption);
                 var arch = parseResult.GetValue(ArchOption);
 
@@ -346,7 +348,7 @@ namespace MSStore.CLI.Commands
                         return await _telemetryClient.TrackCommandEventAsync<Handler>(-5, props, ct);
                     }
 
-                    result = await projectPublisher.PublishAsync(pathOrUrl, app, flightId, outputDirectory, false, packageRolloutPercentage, storePackagedAPI, ct);
+                    result = await projectPublisher.PublishAsync(pathOrUrl, app, flightId, outputDirectory, false, packageRolloutPercentage, uploadTimeout, storePackagedAPI, ct);
                 }
 
                 return await _telemetryClient.TrackCommandEventAsync<Handler>(result, props, ct);

--- a/MSStore.CLI/Helpers/IStorePackagedAPIExtensions.cs
+++ b/MSStore.CLI/Helpers/IStorePackagedAPIExtensions.cs
@@ -352,6 +352,7 @@ namespace MSStore.CLI.Helpers
             IEnumerable<FileInfo> input,
             bool noCommit,
             float? packageRolloutPercentage,
+            long uploadTimeout,
             IBrowserLauncher browserLauncher,
             IConsoleReader consoleReader,
             IZipFileManager zipFileManager,
@@ -567,7 +568,7 @@ namespace MSStore.CLI.Helpers
                     var task = ctx.AddTask("[green]Uploading Bundle to [u]Azure blob[/][/]");
                     try
                     {
-                        await azureBlobManager.UploadFileAsync(submission.FileUploadUrl, uploadZipFilePath, task, ct);
+                        await azureBlobManager.UploadFileAsync(submission.FileUploadUrl, uploadZipFilePath, task, uploadTimeout, ct);
                         ansiConsole.MarkupLine($":check_mark_button: [green]Successfully uploaded the application package.[/]");
                         return true;
                     }

--- a/MSStore.CLI/ProjectConfigurators/ElectronProjectConfigurator.cs
+++ b/MSStore.CLI/ProjectConfigurators/ElectronProjectConfigurator.cs
@@ -406,7 +406,7 @@ namespace MSStore.CLI.ProjectConfigurators
             _electronManifest ??= await _electronManifestManager.LoadAsync(fileInfo, ct);
         }
 
-        public override async Task<int> PublishAsync(string pathOrUrl, DevCenterApplication? app, string? flightId, DirectoryInfo? inputDirectory, bool noCommit, float? packageRolloutPercentage, IStorePackagedAPI storePackagedAPI, CancellationToken ct)
+        public override async Task<int> PublishAsync(string pathOrUrl, DevCenterApplication? app, string? flightId, DirectoryInfo? inputDirectory, bool noCommit, float? packageRolloutPercentage, long uploadTimeout, IStorePackagedAPI storePackagedAPI, CancellationToken ct)
         {
             if (_electronManifest == null)
             {
@@ -414,7 +414,7 @@ namespace MSStore.CLI.ProjectConfigurators
                 await EnsureElectronManifestAsync(manifestFile, ct);
             }
 
-            return await base.PublishAsync(pathOrUrl, app, flightId, inputDirectory, noCommit, packageRolloutPercentage, storePackagedAPI, ct);
+            return await base.PublishAsync(pathOrUrl, app, flightId, inputDirectory, noCommit, packageRolloutPercentage, uploadTimeout, storePackagedAPI, ct);
         }
     }
 }

--- a/MSStore.CLI/ProjectConfigurators/FileProjectConfigurator.cs
+++ b/MSStore.CLI/ProjectConfigurators/FileProjectConfigurator.cs
@@ -138,7 +138,7 @@ namespace MSStore.CLI.ProjectConfigurators
             return Task.FromResult<(string, List<SubmissionImage>)>((description, images));
         }
 
-        public virtual async Task<int> PublishAsync(string pathOrUrl, DevCenterApplication? app, string? flightId, DirectoryInfo? inputDirectory, bool noCommit, float? packageRolloutPercentage, IStorePackagedAPI storePackagedAPI, CancellationToken ct)
+        public virtual async Task<int> PublishAsync(string pathOrUrl, DevCenterApplication? app, string? flightId, DirectoryInfo? inputDirectory, bool noCommit, float? packageRolloutPercentage, long uploadTimeout, IStorePackagedAPI storePackagedAPI, CancellationToken ct)
         {
             var (projectRootPath, projectFile) = GetInfo(pathOrUrl);
 
@@ -181,7 +181,7 @@ namespace MSStore.CLI.ProjectConfigurators
 
             Logger.LogInformation("Trying to publish these {FileCount} files: {FileNames}", packageFiles.Count(), string.Join(", ", packageFiles.Select(f => $"'{f.FullName}'")));
 
-            return await storePackagedAPI.PublishAsync(ErrorAnsiConsole, app, flightId, GetFirstSubmissionDataAsync, AllowTargetFutureDeviceFamilies, output, packageFiles, noCommit, packageRolloutPercentage, _browserLauncher, _consoleReader, _zipFileManager, _fileDownloader, _azureBlobManager, _environmentInformationService, _logger, ct);
+            return await storePackagedAPI.PublishAsync(ErrorAnsiConsole, app, flightId, GetFirstSubmissionDataAsync, AllowTargetFutureDeviceFamilies, output, packageFiles, noCommit, packageRolloutPercentage, uploadTimeout, _browserLauncher, _consoleReader, _zipFileManager, _fileDownloader, _azureBlobManager, _environmentInformationService, _logger, ct);
         }
 
         protected virtual DirectoryInfo GetInputDirectory(DirectoryInfo projectRootPath)

--- a/MSStore.CLI/ProjectConfigurators/IProjectPublisher.cs
+++ b/MSStore.CLI/ProjectConfigurators/IProjectPublisher.cs
@@ -17,6 +17,6 @@ namespace MSStore.CLI.ProjectConfigurators
         SearchOption PackageFilesSearchOption { get; }
         AllowTargetFutureDeviceFamily[] AllowTargetFutureDeviceFamilies { get; }
         Task<bool> CanPublishAsync(string pathOrUrl, CancellationToken ct);
-        Task<int> PublishAsync(string pathOrUrl, DevCenterApplication? app, string? flightId, DirectoryInfo? inputDirectory, bool noCommit, float? packageRolloutPercentage, IStorePackagedAPI storePackagedAPI, CancellationToken ct);
+        Task<int> PublishAsync(string pathOrUrl, DevCenterApplication? app, string? flightId, DirectoryInfo? inputDirectory, bool noCommit, float? packageRolloutPercentage, long uploadTimeout, IStorePackagedAPI storePackagedAPI, CancellationToken ct);
     }
 }

--- a/MSStore.CLI/ProjectConfigurators/MSIXProjectPublisher.cs
+++ b/MSStore.CLI/ProjectConfigurators/MSIXProjectPublisher.cs
@@ -94,7 +94,7 @@ namespace MSStore.CLI.ProjectConfigurators
             return Task.FromResult(_appXManifestManager.GetAppId(appxManifest));
         }
 
-        public async Task<int> PublishAsync(string pathOrUrl, DevCenterApplication? app, string? flightId, DirectoryInfo? inputDirectory, bool noCommit, float? packageRolloutPercentage, IStorePackagedAPI storePackagedAPI, CancellationToken ct)
+        public async Task<int> PublishAsync(string pathOrUrl, DevCenterApplication? app, string? flightId, DirectoryInfo? inputDirectory, bool noCommit, float? packageRolloutPercentage, long uploadTimeout, IStorePackagedAPI storePackagedAPI, CancellationToken ct)
         {
             var msix = new FileInfo(pathOrUrl);
 
@@ -131,7 +131,7 @@ namespace MSStore.CLI.ProjectConfigurators
 
             _logger.LogInformation("Trying to publish these {FileCount} files: {FileNames}", packageFiles.Count, string.Join(", ", packageFiles.Select(f => $"'{f.FullName}'")));
 
-            return await storePackagedAPI.PublishAsync(_ansiConsole, _app, flightId, GetFirstSubmissionDataAsync, AllowTargetFutureDeviceFamilies, output, packageFiles, noCommit, packageRolloutPercentage, _browserLauncher, _consoleReader, _zipFileManager, _fileDownloader, _azureBlobManager, _environmentInformationService, _logger, ct);
+            return await storePackagedAPI.PublishAsync(_ansiConsole, _app, flightId, GetFirstSubmissionDataAsync, AllowTargetFutureDeviceFamilies, output, packageFiles, noCommit, packageRolloutPercentage, uploadTimeout, _browserLauncher, _consoleReader, _zipFileManager, _fileDownloader, _azureBlobManager, _environmentInformationService, _logger, ct);
         }
 
         private Task<(string Description, List<SubmissionImage> Images)> GetFirstSubmissionDataAsync(string listingLanguage, CancellationToken ct)

--- a/MSStore.CLI/ProjectConfigurators/PWAProjectConfigurator.cs
+++ b/MSStore.CLI/ProjectConfigurators/PWAProjectConfigurator.cs
@@ -317,7 +317,7 @@ namespace MSStore.CLI.ProjectConfigurators
             return Task.FromResult((0, (DirectoryInfo?)new DirectoryInfo(pathOrUrl)));
         }
 
-        public async Task<int> PublishAsync(string pathOrUrl, DevCenterApplication? app, string? flightId, DirectoryInfo? inputDirectory, bool noCommit, float? packageRolloutPercentage, IStorePackagedAPI storePackagedAPI, CancellationToken ct)
+        public async Task<int> PublishAsync(string pathOrUrl, DevCenterApplication? app, string? flightId, DirectoryInfo? inputDirectory, bool noCommit, float? packageRolloutPercentage, long uploadTimeout, IStorePackagedAPI storePackagedAPI, CancellationToken ct)
         {
             Uri? uri = GetUri(pathOrUrl);
 
@@ -391,6 +391,7 @@ namespace MSStore.CLI.ProjectConfigurators
                 packageFiles,
                 noCommit,
                 packageRolloutPercentage,
+                uploadTimeout,
                 _browserLauncher,
                 _consoleReader,
                 _zipFileManager,

--- a/MSStore.CLI/Services/AzureBlobManager.cs
+++ b/MSStore.CLI/Services/AzureBlobManager.cs
@@ -18,11 +18,12 @@ namespace MSStore.CLI.Services
     {
         private readonly TelemetryClient _telemetryClient = telemetryClient ?? throw new ArgumentNullException(nameof(telemetryClient));
 
-        public async Task<string> UploadFileAsync(string blobUri, string localFilePath, IProgress<double> progress, CancellationToken ct)
+        public async Task<string> UploadFileAsync(string blobUri, string localFilePath, IProgress<double> progress, long uploadTimeout, CancellationToken ct)
         {
             using var fileStream = new FileStream(localFilePath, FileMode.Open, FileAccess.Read);
 
             var blobClientOptions = new BlobClientOptions();
+            blobClientOptions.Retry.NetworkTimeout = TimeSpan.FromSeconds(uploadTimeout);
             blobClientOptions.AddPolicy(new AddCorrelationIdHeaderPolicy(_telemetryClient), HttpPipelinePosition.PerCall);
             var blobClient = new BlobClient(new Uri(blobUri.Replace("+", "%2B")), blobClientOptions);
             var blobUploadOptions = new BlobUploadOptions

--- a/MSStore.CLI/Services/IAzureBlobManager.cs
+++ b/MSStore.CLI/Services/IAzureBlobManager.cs
@@ -9,6 +9,6 @@ namespace MSStore.CLI.Services
 {
     internal interface IAzureBlobManager
     {
-        Task<string> UploadFileAsync(string blobUri, string localFilePath, IProgress<double> progress, CancellationToken ct);
+        Task<string> UploadFileAsync(string blobUri, string localFilePath, IProgress<double> progress, long uploadTimeout, CancellationToken ct);
     }
 }


### PR DESCRIPTION
Introduces a new command line parameter; when set to some value, this value will be used as timeout for upload to blob storage. If value won't be specified, will be used default value 100 seconds (current used value)

I used for parameter name that will reflect, what it will do.
Should be docs updated somehow?

Fixes: #113 