### PR TITLE
Changes to remove the obsolete packages during the publish flow

### DIFF
--- a/MSStore.CLI/Helpers/IStorePackagedAPIExtensions.cs
+++ b/MSStore.CLI/Helpers/IStorePackagedAPIExtensions.cs
@@ -648,11 +648,11 @@ namespace MSStore.CLI.Helpers
                         List<ApplicationPackage>? packages;
                         if (devCenterSubmission != null)
                         {
-                            packages = devCenterSubmission.ApplicationPackages.FilterUnsupported();
+                            packages = devCenterSubmission.ApplicationPackages;
                         }
                         else if (devCenterFlightSubmission != null)
                         {
-                            packages = devCenterFlightSubmission.FlightPackages.FilterUnsupported();
+                            packages = devCenterFlightSubmission.FlightPackages;
                         }
                         else
                         {
@@ -663,7 +663,7 @@ namespace MSStore.CLI.Helpers
 
                         foreach (var file in packageFiles)
                         {
-                            var applicationPackage = packages.FirstOrDefault(p => Path.GetExtension(p.FileName) == file.Extension);
+                            var applicationPackage = packages?.FirstOrDefault(p => Path.GetExtension(p.FileName) == file.Extension);
                             if (applicationPackage != null)
                             {
                                 if (applicationPackage.FileStatus == FileStatus.PendingUpload)


### PR DESCRIPTION
Removed the filtering condition as it was not required and due to this, the obsolete packages were not getting deleted during the publish scenario.