### PR TITLE
Add rate limit handling in http client

### DIFF
--- a/MSStore.CLI/Program.cs
+++ b/MSStore.CLI/Program.cs
@@ -25,6 +25,7 @@ using MSStore.CLI.Services;
 using MSStore.CLI.Services.CredentialManager;
 using MSStore.CLI.Services.ElectronManager;
 using MSStore.CLI.Services.Graph;
+using MSStore.CLI.Services.Http;
 using MSStore.CLI.Services.PartnerCenter;
 using MSStore.CLI.Services.PWABuilder;
 using MSStore.CLI.Services.Telemetry;
@@ -117,7 +118,7 @@ namespace MSStore.CLI
                         })
                         .ConfigurePrimaryHttpMessageHandler(() =>
                         {
-                            return new HttpClientHandler
+                            return new RetryAfterHttpHandler
                             {
                                 CheckCertificateRevocationList = true
                             };

--- a/MSStore.CLI/Services/Http/RetryAfterHttpHandler.cs
+++ b/MSStore.CLI/Services/Http/RetryAfterHttpHandler.cs
@@ -1,0 +1,41 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Linq;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace MSStore.CLI.Services.Http
+{
+    public sealed class RetryAfterHttpHandler : HttpClientHandler
+    {
+        /// <inheritdoc/>
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            do
+            {
+                var httpResponse = await base.SendAsync(request, cancellationToken);
+                if (httpResponse.StatusCode == System.Net.HttpStatusCode.TooManyRequests)
+                {
+                    if (httpResponse.Headers.TryGetValues("Retry-After", out var values))
+                    {
+                        var retryAfter = values.FirstOrDefault();
+                        if (int.TryParse(retryAfter, out int delaySeconds))
+                        {
+                            await Task.Delay(delaySeconds * 1000, cancellationToken);
+                            continue;
+                        }
+                    }
+                    await Task.Delay(500, cancellationToken);
+                    continue;
+                }
+                else
+                {
+                    return httpResponse;
+                }
+            }
+            while (true);
+        }
+    }
+}


### PR DESCRIPTION
This adds a rate limit handler for the http client that is used to interact with the store api's.

fixes #125 