### PR TITLE
Fix unhandled ObjectDisposedException from the upload progress callback

### DIFF
--- a/MSStore.CLI.UnitTests/AzureBlobManagerUnitTests.cs
+++ b/MSStore.CLI.UnitTests/AzureBlobManagerUnitTests.cs
@@ -1,0 +1,95 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using MSStore.CLI.Services;
+
+namespace MSStore.CLI.UnitTests
+{
+    [TestClass]
+    public class AzureBlobManagerUnitTests
+    {
+        private sealed class RecordingProgress : IProgress<double>
+        {
+            public List<double> Reported { get; } = [];
+
+            public void Report(double value) => Reported.Add(value);
+        }
+
+        private sealed class ThrowingProgress : IProgress<double>
+        {
+            public void Report(double value) => throw new InvalidOperationException("Progress display already torn down.");
+        }
+
+        /// <summary>
+        /// Regression test for https://github.com/microsoft/msstore-cli/issues/154.
+        ///
+        /// The upload progress callback used to read fileStream.Length. Progress&lt;T&gt; dispatches its
+        /// handlers on the thread pool, so a queued callback could run after UploadFileAsync had returned or
+        /// thrown and the `using` had disposed the stream. That threw ObjectDisposedException on a
+        /// thread-pool thread, outside the caller's try/catch, and took the whole process down.
+        /// </summary>
+        [TestMethod]
+        public void CreateProgressCallbackDoesNotTouchTheFileStreamAfterItIsDisposed()
+        {
+            var path = Path.GetTempFileName();
+
+            try
+            {
+                File.WriteAllBytes(path, new byte[1000]);
+
+                var progress = new RecordingProgress();
+                Action<long> callback;
+
+                using (var fileStream = new FileStream(path, FileMode.Open, FileAccess.Read))
+                {
+                    callback = AzureBlobManager.CreateProgressCallback(fileStream.Length, progress);
+                }
+
+                // The stream is now disposed, exactly as it is when a late callback is dispatched.
+                callback(250);
+
+                Assert.AreSequenceEqual([25d], progress.Reported);
+            }
+            finally
+            {
+                File.Delete(path);
+            }
+        }
+
+        [TestMethod]
+        public void CreateProgressCallbackReportsPercentage()
+        {
+            var progress = new RecordingProgress();
+            var callback = AzureBlobManager.CreateProgressCallback(200, progress);
+
+            callback(0);
+            callback(50);
+            callback(200);
+
+            Assert.AreSequenceEqual([0d, 25d, 100d], progress.Reported);
+        }
+
+        [TestMethod]
+        public void CreateProgressCallbackDoesNotReportForAnEmptyFile()
+        {
+            var progress = new RecordingProgress();
+            var callback = AzureBlobManager.CreateProgressCallback(0, progress);
+
+            // Must not divide by zero and push NaN/Infinity into the progress display.
+            callback(0);
+
+            Assert.IsEmpty(progress.Reported);
+        }
+
+        [TestMethod]
+        public void CreateProgressCallbackSwallowsExceptionsFromTheProgressConsumer()
+        {
+            // The CLI passes a Spectre.Console ProgressTask, which can throw once the progress display has
+            // been torn down. A late callback runs on a thread-pool thread, so anything escaping here would
+            // terminate the process.
+            var callback = AzureBlobManager.CreateProgressCallback(100, new ThrowingProgress());
+
+            callback(50);
+        }
+    }
+}

--- a/MSStore.CLI/Services/AzureBlobManager.cs
+++ b/MSStore.CLI/Services/AzureBlobManager.cs
@@ -19,6 +19,11 @@ namespace MSStore.CLI.Services
         {
             using var fileStream = new FileStream(localFilePath, FileMode.Open, FileAccess.Read);
 
+            // Capture the length up front. Progress<T> dispatches its handlers on the thread pool, so a
+            // callback can still run after this method has returned (or thrown) and fileStream has been
+            // disposed. The callback must therefore never touch fileStream.
+            var totalBytes = fileStream.Length;
+
             var blobClientOptions = new BlobClientOptions();
             blobClientOptions.Retry.NetworkTimeout = TimeSpan.FromSeconds(uploadTimeout);
             blobClientOptions.AddPolicy(new AddCorrelationIdHeaderPolicy(), HttpPipelinePosition.PerCall);
@@ -29,10 +34,7 @@ namespace MSStore.CLI.Services
                 {
                     ContentType = "application/zip"
                 },
-                ProgressHandler = new Progress<long>(bytesTransferred =>
-                {
-                    progress.Report((double)bytesTransferred * 100 / fileStream.Length);
-                }),
+                ProgressHandler = new Progress<long>(CreateProgressCallback(totalBytes, progress)),
             };
 
             var response = await blobClient.UploadAsync(fileStream, blobUploadOptions, ct);
@@ -44,6 +46,25 @@ namespace MSStore.CLI.Services
             {
                 throw new MSStoreException(response.GetRawResponse().ReasonPhrase);
             }
+        }
+
+        internal static Action<long> CreateProgressCallback(long totalBytes, IProgress<double> progress)
+        {
+            return bytesTransferred =>
+            {
+                try
+                {
+                    if (totalBytes > 0)
+                    {
+                        progress.Report((double)bytesTransferred * 100 / totalBytes);
+                    }
+                }
+                catch (Exception)
+                {
+                    // Progress reporting is best-effort. This runs on a thread-pool thread, outside the
+                    // caller's try/catch, so anything that escapes here would terminate the process.
+                }
+            };
         }
 
         public class AddCorrelationIdHeaderPolicy() : HttpPipelineSynchronousPolicy


### PR DESCRIPTION
Fixes #154

## Problem

`AzureBlobManager.UploadFileAsync` built its Azure upload progress handler as a lambda that read `fileStream.Length` on every tick:

```csharp
using var fileStream = new FileStream(localFilePath, FileMode.Open, FileAccess.Read);
...
ProgressHandler = new Progress<long>(bytesTransferred =>
{
    progress.Report((double)bytesTransferred * 100 / fileStream.Length);
}),
```

`Progress<T>` dispatches its handlers **asynchronously** onto the thread pool (the CLI has no `SynchronizationContext`). When `UploadAsync` returns — or throws — the `using` disposes the stream while callbacks can still be queued. A queued callback then calls `get_Length()` on a closed stream and throws `ObjectDisposedException` on a thread-pool thread, **outside** the caller's `try`/`catch` in `IStorePackagedAPIExtensions`, so it is unhandled and kills the process:

```
Uploading Bundle to Azure blob: 0%
Error while uploading the application package.        <- caller's catch DID run
Unhandled exception. System.ObjectDisposedException: Cannot access a closed file.
   at System.Progress`1.InvokeHandlers(Object state)
   at System.Threading.ThreadPoolWorkQueue.Dispatch()
```

The crash is at 0%, *after* the caller's `catch` printed — so the ordering is: `UploadAsync` fails fast → `using` disposes → `catch` handles the upload failure → a still-queued callback takes the process down. Because `publish` has already run `Deleting existing Submission` by that point, this is disruptive in CI.

The race is pre-existing, but #133's move to .NET 10 with native AOT / single-file changed thread-pool scheduling and disposal timing enough to make it deterministic in v0.4.0.

## Fix

Capture the length once, before the upload, so the callback never touches the stream, and guard the handler body so a late callback can never escape onto the thread pool.

The guard is not redundant: `progress` is a Spectre.Console `ProgressTask`, and reporting into it after the progress display has been torn down can also throw from a thread-pool thread. The `totalBytes > 0` check keeps `NaN`/`Infinity` out of the display for a 0-byte package.

Upload behaviour itself is unchanged — a failed upload still surfaces through the existing `catch` and returns `-1`.

## Scope

`AzureBlobManager` is the only site with this pattern. `FileDownloader.DownloadAsync` and `PWABuilderClient.GenerateZipAsync` report progress synchronously on the awaiting thread and do not capture a disposed stream.

## Verification

- Reproduced against a verbatim copy of the original `UploadFileAsync` (same `Azure.Storage.Blobs` 12.29.1) pointed at a local blob endpoint that accepts part of the body then aborts: the reported `ObjectDisposedException` from `Progress<T>.InvokeHandlers` fires on every run, 13–18 callbacks escaping after the `catch` had already completed.
- The same harness run against the patched code in this PR: 0 unhandled exceptions, empty stderr, progress still reported normally. Repeated alternating buggy/fixed runs are consistent.
- New unit tests in `MSStore.CLI.UnitTests/AzureBlobManagerUnitTests.cs` lock in the invariant that the callback does not touch the file stream, plus percentage correctness, the 0-byte case, and the consumer-throws case.
- Full suite run on both `net10.0` and `net10.0-windows10.0.17763.0` (the CI TFM); remaining failures are pre-existing and were confirmed against a clean baseline.

Side note for anyone reproducing this: on .NET 10 CoreCLR an unhandled thread-pool exception no longer terminates the process by default. The shipped CLI is NativeAOT (`PublishAot=true`), which fail-fasts — which is why the reporter sees exit code 1.