### PR TITLE
Write JSON payloads straight to stdout instead of through Spectre

### DIFF
--- a/MSStore.CLI.UnitTests/BaseCommandLineTest.cs
+++ b/MSStore.CLI.UnitTests/BaseCommandLineTest.cs
@@ -372,7 +372,7 @@ namespace MSStore.CLI.UnitTests
                 });
         }
 
-        protected void AddDefaultFakeSubmission()
+        protected void AddDefaultFakeSubmission(string listingDescription = "BaseListingDescription")
         {
             var fakeSubmission = new DevCenterSubmission
             {
@@ -406,7 +406,7 @@ namespace MSStore.CLI.UnitTests
                             {
                                 BaseListing = new BaseListing
                                 {
-                                    Description = "BaseListingDescription"
+                                    Description = listingDescription
                                 }
                             }
                         }
@@ -764,6 +764,10 @@ namespace MSStore.CLI.UnitTests
             var outputCapture = new OutputCapture(Console.Out);
             var errorCapture = RefreshAnsiConsole();
 
+            // Only stdout is redirected: the error capture is reached exclusively through
+            // ErrorAnsiConsole, mirroring how Program.cs keeps the two streams apart.
+            Console.SetOut(outputCapture);
+
             AnsiConsole.Console = AnsiConsole.Create(new AnsiConsoleSettings
             {
                 Ansi = AnsiSupport.Yes,
@@ -871,7 +875,6 @@ namespace MSStore.CLI.UnitTests
             public OutputCapture(TextWriter textWriter)
             {
                 _stdOutWriter = textWriter;
-                Console.SetOut(this);
                 Captured = new StringWriter();
             }
 

--- a/MSStore.CLI.UnitTests/PackageCommandUnitTests.cs
+++ b/MSStore.CLI.UnitTests/PackageCommandUnitTests.cs
@@ -568,5 +568,27 @@ namespace MSStore.CLI.UnitTests
             result.Error.Should().Contain("The packaged app is here:");
             result.Output.Split(['\r', '\n'], StringSplitOptions.RemoveEmptyEntries).Should().ContainSingle().Which.Should().Contain(path);
         }
+
+        [TestMethod]
+        public async Task PackageCommandForPWAsShouldPrintAnAbsolutePathForARelativeArgument()
+        {
+            var path = CopyFilesRecursively("PWAProject");
+
+            // CopyFilesRecursively hands back a path relative to the test working directory, and
+            // the PWA packager is the only one that echoes the argument straight back as its
+            // output directory instead of deriving it from a built file. So this is the case
+            // where DirectoryInfo.ToString() would emit a bare relative path to stdout.
+            Path.IsPathFullyQualified(path).Should().BeFalse();
+
+            var result = await ParseAndInvokeAsync(
+                [
+                    "package",
+                    path
+                ]);
+
+            result.Error.Should().Contain("The packaged app is here:");
+            result.Output.Split(['\r', '\n'], StringSplitOptions.RemoveEmptyEntries)
+                .Should().ContainSingle().Which.Should().Be(Path.GetFullPath(path));
+        }
     }
 }

--- a/MSStore.CLI.UnitTests/PackageCommandUnitTests.cs
+++ b/MSStore.CLI.UnitTests/PackageCommandUnitTests.cs
@@ -99,7 +99,7 @@ namespace MSStore.CLI.UnitTests
                 ]);
 
             result.Error.Should().Contain("The packaged app is here:");
-            result.Output.Split(['\r', '\n'], StringSplitOptions.RemoveEmptyEntries).Should().ContainSingle(line => line.Contains(customPath));
+            result.Output.Split(['\r', '\n'], StringSplitOptions.RemoveEmptyEntries).Should().ContainSingle().Which.Should().Contain(customPath);
 
             ExternalCommandExecutor.VerifyAll();
         }
@@ -216,7 +216,7 @@ namespace MSStore.CLI.UnitTests
                 ]);
 
             result.Error.Should().Contain("The packaged app is here:");
-            result.Output.Split(['\r', '\n'], StringSplitOptions.RemoveEmptyEntries).Should().ContainSingle(line => line.Contains(customPath));
+            result.Output.Split(['\r', '\n'], StringSplitOptions.RemoveEmptyEntries).Should().ContainSingle().Which.Should().Contain(customPath);
 
             ExternalCommandExecutor.VerifyAll();
         }
@@ -295,7 +295,7 @@ namespace MSStore.CLI.UnitTests
                 ]);
 
             result.Error.Should().Contain("The packaged app is here:");
-            result.Output.Split(['\r', '\n'], StringSplitOptions.RemoveEmptyEntries).Should().ContainSingle(line => line.Contains(customPath));
+            result.Output.Split(['\r', '\n'], StringSplitOptions.RemoveEmptyEntries).Should().ContainSingle().Which.Should().Contain(customPath);
 
             ExternalCommandExecutor.VerifyAll();
         }
@@ -375,7 +375,7 @@ namespace MSStore.CLI.UnitTests
                 ]);
 
             result.Error.Should().Contain("The packaged app is here:");
-            result.Output.Split(['\r', '\n'], StringSplitOptions.RemoveEmptyEntries).Should().ContainSingle(line => line.Contains(path));
+            result.Output.Split(['\r', '\n'], StringSplitOptions.RemoveEmptyEntries).Should().ContainSingle().Which.Should().Contain(path);
         }
 
         [TestMethod]
@@ -426,7 +426,7 @@ namespace MSStore.CLI.UnitTests
                 ]);
 
             result.Error.Should().Contain("The packaged app is here:");
-            result.Output.Split(['\r', '\n'], StringSplitOptions.RemoveEmptyEntries).Should().ContainSingle(line => line.Contains(customPath));
+            result.Output.Split(['\r', '\n'], StringSplitOptions.RemoveEmptyEntries).Should().ContainSingle().Which.Should().Contain(customPath);
         }
 
         private void SetupPubGet(DirectoryInfo dirInfo)
@@ -478,7 +478,7 @@ namespace MSStore.CLI.UnitTests
                 ]);
 
             result.Error.Should().Contain("The packaged app is here:");
-            result.Output.Split(['\r', '\n'], StringSplitOptions.RemoveEmptyEntries).Should().ContainSingle(line => line.Contains(path));
+            result.Output.Split(['\r', '\n'], StringSplitOptions.RemoveEmptyEntries).Should().ContainSingle().Which.Should().Contain(path);
         }
 
         [TestMethod]
@@ -514,7 +514,7 @@ namespace MSStore.CLI.UnitTests
                 ]);
 
             result.Error.Should().Contain("The packaged app is here:");
-            result.Output.Split(['\r', '\n'], StringSplitOptions.RemoveEmptyEntries).Should().ContainSingle(line => line.Contains(path));
+            result.Output.Split(['\r', '\n'], StringSplitOptions.RemoveEmptyEntries).Should().ContainSingle().Which.Should().Contain(path);
         }
 
         [TestMethod]
@@ -566,7 +566,7 @@ namespace MSStore.CLI.UnitTests
                 ]);
 
             result.Error.Should().Contain("The packaged app is here:");
-            result.Output.Split(['\r', '\n'], StringSplitOptions.RemoveEmptyEntries).Should().ContainSingle(line => line.Contains(path));
+            result.Output.Split(['\r', '\n'], StringSplitOptions.RemoveEmptyEntries).Should().ContainSingle().Which.Should().Contain(path);
         }
     }
 }

--- a/MSStore.CLI.UnitTests/PackageCommandUnitTests.cs
+++ b/MSStore.CLI.UnitTests/PackageCommandUnitTests.cs
@@ -99,7 +99,7 @@ namespace MSStore.CLI.UnitTests
                 ]);
 
             result.Error.Should().Contain("The packaged app is here:");
-            result.Output.Should().Contain(customPath);
+            result.Output.Split(['\r', '\n'], StringSplitOptions.RemoveEmptyEntries).Should().ContainSingle(line => line.Contains(customPath));
 
             ExternalCommandExecutor.VerifyAll();
         }
@@ -216,7 +216,7 @@ namespace MSStore.CLI.UnitTests
                 ]);
 
             result.Error.Should().Contain("The packaged app is here:");
-            result.Output.Should().Contain(customPath);
+            result.Output.Split(['\r', '\n'], StringSplitOptions.RemoveEmptyEntries).Should().ContainSingle(line => line.Contains(customPath));
 
             ExternalCommandExecutor.VerifyAll();
         }
@@ -295,7 +295,7 @@ namespace MSStore.CLI.UnitTests
                 ]);
 
             result.Error.Should().Contain("The packaged app is here:");
-            result.Output.Should().Contain(customPath);
+            result.Output.Split(['\r', '\n'], StringSplitOptions.RemoveEmptyEntries).Should().ContainSingle(line => line.Contains(customPath));
 
             ExternalCommandExecutor.VerifyAll();
         }
@@ -375,7 +375,7 @@ namespace MSStore.CLI.UnitTests
                 ]);
 
             result.Error.Should().Contain("The packaged app is here:");
-            result.Output.Should().Contain(path);
+            result.Output.Split(['\r', '\n'], StringSplitOptions.RemoveEmptyEntries).Should().ContainSingle(line => line.Contains(path));
         }
 
         [TestMethod]
@@ -426,7 +426,7 @@ namespace MSStore.CLI.UnitTests
                 ]);
 
             result.Error.Should().Contain("The packaged app is here:");
-            result.Output.Should().Contain(customPath);
+            result.Output.Split(['\r', '\n'], StringSplitOptions.RemoveEmptyEntries).Should().ContainSingle(line => line.Contains(customPath));
         }
 
         private void SetupPubGet(DirectoryInfo dirInfo)
@@ -478,7 +478,7 @@ namespace MSStore.CLI.UnitTests
                 ]);
 
             result.Error.Should().Contain("The packaged app is here:");
-            result.Output.Should().Contain(path);
+            result.Output.Split(['\r', '\n'], StringSplitOptions.RemoveEmptyEntries).Should().ContainSingle(line => line.Contains(path));
         }
 
         [TestMethod]
@@ -514,7 +514,7 @@ namespace MSStore.CLI.UnitTests
                 ]);
 
             result.Error.Should().Contain("The packaged app is here:");
-            result.Output.Should().Contain(path);
+            result.Output.Split(['\r', '\n'], StringSplitOptions.RemoveEmptyEntries).Should().ContainSingle(line => line.Contains(path));
         }
 
         [TestMethod]
@@ -566,7 +566,7 @@ namespace MSStore.CLI.UnitTests
                 ]);
 
             result.Error.Should().Contain("The packaged app is here:");
-            result.Output.Should().Contain(path);
+            result.Output.Split(['\r', '\n'], StringSplitOptions.RemoveEmptyEntries).Should().ContainSingle(line => line.Contains(path));
         }
     }
 }

--- a/MSStore.CLI.UnitTests/SubmissionCommandPackagedUnitTests.cs
+++ b/MSStore.CLI.UnitTests/SubmissionCommandPackagedUnitTests.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System.Text.Json;
 using MSStore.API.Packaged.Models;
 
 namespace MSStore.CLI.UnitTests
@@ -66,6 +67,40 @@ namespace MSStore.CLI.UnitTests
 
             result.Output.Should().Contain("\"Id\": \"123456789\"");
             result.Output.Should().Contain("\"FileUploadUrl\": \"https://azureblob.com/fileupload\"");
+        }
+
+        [TestMethod]
+        public async Task PackagedSubmissionGetCommandShouldNotWrapJsonOutput()
+        {
+            // Longer than the width the test console renders at, and sprinkled with characters
+            // that the serializer escapes as \uXXXX, so a wrap would both break the JSON and
+            // corrupt the description.
+            var longDescription = string.Concat(
+                Enumerable.Repeat("Sync your mail & calendar across every device without a fuss. ", 12));
+
+            AddDefaultFakeSubmission(longDescription);
+
+            FakeApps[0].LastPublishedApplicationSubmission = new ApplicationSubmissionInfo
+            {
+                Id = "123456789"
+            };
+
+            var result = await ParseAndInvokeAsync(
+                [
+                    "submission",
+                    "get",
+                    FakeApps[0].Id!
+                ]);
+
+            using var json = JsonDocument.Parse(result.Output);
+
+            json.RootElement
+                .GetProperty("Listings")
+                .GetProperty("en-us")
+                .GetProperty("BaseListing")
+                .GetProperty("Description")
+                .GetString()
+                .Should().Be(longDescription);
         }
 
         [TestMethod]

--- a/MSStore.CLI.UnitTests/SubmissionCommandUnpackagedUnitTests.cs
+++ b/MSStore.CLI.UnitTests/SubmissionCommandUnpackagedUnitTests.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System.Text.Json;
 using MSStore.API.Models;
 
 namespace MSStore.CLI.UnitTests
@@ -66,6 +67,50 @@ namespace MSStore.CLI.UnitTests
                 ]);
 
             result.Output.Should().Contain("\"PackageId\": \"12345\"");
+        }
+
+        [TestMethod]
+        public async Task UnpackagedSubmissionGetCommandShouldNotWrapJsonOutput()
+        {
+            // Longer than the width the test console renders at, and sprinkled with characters
+            // that the serializer escapes as \uXXXX, so a wrap would both break the JSON and
+            // corrupt the description.
+            var longDescription = string.Concat(
+                Enumerable.Repeat("Sync your mail & calendar across every device without a fuss. ", 12));
+
+            FakeStoreAPI
+                .Setup(x => x.GetDraftAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new ResponseWrapper<ListingsMetadataResponse>
+                {
+                    IsSuccess = true,
+                    ResponseData = new ListingsMetadataResponse
+                    {
+                        Listings =
+                            [
+                                new Listing
+                                {
+                                    Language = "en-us",
+                                    Description = longDescription
+                                }
+                            ]
+                    }
+                });
+
+            var result = await ParseAndInvokeAsync(
+                [
+                    "submission",
+                    "get",
+                    Guid.Empty.ToString()
+                ]);
+
+            using var json = JsonDocument.Parse(result.Output);
+
+            json.RootElement
+                .GetProperty("ResponseData")
+                .GetProperty("Listings")[0]
+                .GetProperty("Description")
+                .GetString()
+                .Should().Be(longDescription);
         }
 
         [TestMethod]

--- a/MSStore.CLI.UnitTests/TestData/PWAProject/pwaAppInfo.json
+++ b/MSStore.CLI.UnitTests/TestData/PWAProject/pwaAppInfo.json
@@ -1,0 +1,4 @@
+{
+  "appId": "9PXXXXXXXXXX",
+  "uri": "https://www.microsoft.com"
+}

--- a/MSStore.CLI/Commands/Apps/GetCommand.cs
+++ b/MSStore.CLI/Commands/Apps/GetCommand.cs
@@ -94,7 +94,7 @@ namespace MSStore.CLI.Commands.Apps
                     }
                     else
                     {
-                        AnsiConsole.WriteLine(JsonSerializer.Serialize(app, app.GetType(), SourceGenerationContext.GetCustom(true)));
+                        StandardOutput.WriteLine(JsonSerializer.Serialize(app, app.GetType(), SourceGenerationContext.GetCustom(true)));
                         return await _telemetryClient.TrackCommandEventAsync<Handler>(0, ct);
                     }
                 }

--- a/MSStore.CLI/Commands/Flights/CreateCommand.cs
+++ b/MSStore.CLI/Commands/Flights/CreateCommand.cs
@@ -111,7 +111,7 @@ namespace MSStore.CLI.Commands.Flights
 
                 if (flight != null)
                 {
-                    AnsiConsole.WriteLine(JsonSerializer.Serialize(flight, SourceGenerationContext.GetCustom(true).DevCenterFlight));
+                    StandardOutput.WriteLine(JsonSerializer.Serialize(flight, SourceGenerationContext.GetCustom(true).DevCenterFlight));
                     return await _telemetryClient.TrackCommandEventAsync<Handler>(0, ct);
                 }
 

--- a/MSStore.CLI/Commands/Flights/GetCommand.cs
+++ b/MSStore.CLI/Commands/Flights/GetCommand.cs
@@ -75,7 +75,7 @@ namespace MSStore.CLI.Commands.Flights
 
                 if (flight != null)
                 {
-                    AnsiConsole.WriteLine(JsonSerializer.Serialize(flight, SourceGenerationContext.GetCustom(true).DevCenterFlight));
+                    StandardOutput.WriteLine(JsonSerializer.Serialize(flight, SourceGenerationContext.GetCustom(true).DevCenterFlight));
                     return await _telemetryClient.TrackCommandEventAsync<Handler>(0, ct);
                 }
 

--- a/MSStore.CLI/Commands/Flights/Submission/GetCommand.cs
+++ b/MSStore.CLI/Commands/Flights/Submission/GetCommand.cs
@@ -88,7 +88,7 @@ namespace MSStore.CLI.Commands.Flights.Submission
                     return await _telemetryClient.TrackCommandEventAsync<Handler>(productId, -1, ct);
                 }
 
-                AnsiConsole.WriteLine(JsonSerializer.Serialize(flightSubmission, SourceGenerationContext.GetCustom(true).DevCenterFlightSubmission));
+                StandardOutput.WriteLine(JsonSerializer.Serialize(flightSubmission, SourceGenerationContext.GetCustom(true).DevCenterFlightSubmission));
 
                 return await _telemetryClient.TrackCommandEventAsync<Handler>(productId, 0, ct);
             }

--- a/MSStore.CLI/Commands/Flights/Submission/Rollout/FinalizeCommand.cs
+++ b/MSStore.CLI/Commands/Flights/Submission/Rollout/FinalizeCommand.cs
@@ -101,7 +101,7 @@ namespace MSStore.CLI.Commands.Flights.Submission.Rollout
                     return await _telemetryClient.TrackCommandEventAsync<Handler>(productId, -1, ct);
                 }
 
-                AnsiConsole.WriteLine(JsonSerializer.Serialize(flightSubmissionRollout, SourceGenerationContext.GetCustom(true).PackageRollout));
+                StandardOutput.WriteLine(JsonSerializer.Serialize(flightSubmissionRollout, SourceGenerationContext.GetCustom(true).PackageRollout));
 
                 return await _telemetryClient.TrackCommandEventAsync<Handler>(productId, 0, ct);
             }

--- a/MSStore.CLI/Commands/Flights/Submission/Rollout/GetCommand.cs
+++ b/MSStore.CLI/Commands/Flights/Submission/Rollout/GetCommand.cs
@@ -101,7 +101,7 @@ namespace MSStore.CLI.Commands.Flights.Submission.Rollout
                     return await _telemetryClient.TrackCommandEventAsync<Handler>(productId, -1, ct);
                 }
 
-                AnsiConsole.WriteLine(JsonSerializer.Serialize(flightSubmissionRollout, SourceGenerationContext.GetCustom(true).PackageRollout));
+                StandardOutput.WriteLine(JsonSerializer.Serialize(flightSubmissionRollout, SourceGenerationContext.GetCustom(true).PackageRollout));
 
                 return await _telemetryClient.TrackCommandEventAsync<Handler>(productId, 0, ct);
             }

--- a/MSStore.CLI/Commands/Flights/Submission/Rollout/HaltCommand.cs
+++ b/MSStore.CLI/Commands/Flights/Submission/Rollout/HaltCommand.cs
@@ -101,7 +101,7 @@ namespace MSStore.CLI.Commands.Flights.Submission.Rollout
                     return await _telemetryClient.TrackCommandEventAsync<Handler>(productId, -1, ct);
                 }
 
-                AnsiConsole.WriteLine(JsonSerializer.Serialize(flightSubmissionRollout, SourceGenerationContext.GetCustom(true).PackageRollout));
+                StandardOutput.WriteLine(JsonSerializer.Serialize(flightSubmissionRollout, SourceGenerationContext.GetCustom(true).PackageRollout));
 
                 return await _telemetryClient.TrackCommandEventAsync<Handler>(productId, 0, ct);
             }

--- a/MSStore.CLI/Commands/Flights/Submission/Rollout/UpdateCommand.cs
+++ b/MSStore.CLI/Commands/Flights/Submission/Rollout/UpdateCommand.cs
@@ -119,7 +119,7 @@ namespace MSStore.CLI.Commands.Flights.Submission.Rollout
                     return await _telemetryClient.TrackCommandEventAsync<Handler>(productId, -1, ct);
                 }
 
-                AnsiConsole.WriteLine(JsonSerializer.Serialize(flightSubmissionRollout, SourceGenerationContext.GetCustom(true).PackageRollout));
+                StandardOutput.WriteLine(JsonSerializer.Serialize(flightSubmissionRollout, SourceGenerationContext.GetCustom(true).PackageRollout));
 
                 return await _telemetryClient.TrackCommandEventAsync<Handler>(productId, 0, ct);
             }

--- a/MSStore.CLI/Commands/Flights/Submission/UpdateCommand.cs
+++ b/MSStore.CLI/Commands/Flights/Submission/UpdateCommand.cs
@@ -128,7 +128,7 @@ namespace MSStore.CLI.Commands.Flights.Submission
                     return await _telemetryClient.TrackCommandEventAsync<Handler>(productId, -1, ct);
                 }
 
-                AnsiConsole.WriteLine(JsonSerializer.Serialize(updatedFlightSubmission, SourceGenerationContext.GetCustom(true).DevCenterFlightSubmission));
+                StandardOutput.WriteLine(JsonSerializer.Serialize(updatedFlightSubmission, SourceGenerationContext.GetCustom(true).DevCenterFlightSubmission));
 
                 return await _telemetryClient.TrackCommandEventAsync<Handler>(productId, 0, ct);
             }

--- a/MSStore.CLI/Commands/PackageCommand.cs
+++ b/MSStore.CLI/Commands/PackageCommand.cs
@@ -100,7 +100,7 @@ namespace MSStore.CLI.Commands
                 if (returnCode == 0 && outputDirectory != null)
                 {
                     _ansiConsole.WriteLine($"The packaged app is here:");
-                    AnsiConsole.MarkupLine($"[green bold]{outputDirectory}[/]");
+                    StandardOutput.WriteLine(outputDirectory.ToString());
                 }
 
                 return await _telemetryClient.TrackCommandEventAsync<Handler>(returnCode, props, ct);

--- a/MSStore.CLI/Commands/PackageCommand.cs
+++ b/MSStore.CLI/Commands/PackageCommand.cs
@@ -100,7 +100,7 @@ namespace MSStore.CLI.Commands
                 if (returnCode == 0 && outputDirectory != null)
                 {
                     _ansiConsole.WriteLine($"The packaged app is here:");
-                    StandardOutput.WriteLine(outputDirectory.ToString());
+                    StandardOutput.WriteLine(outputDirectory.FullName);
                 }
 
                 return await _telemetryClient.TrackCommandEventAsync<Handler>(returnCode, props, ct);

--- a/MSStore.CLI/Commands/Submission/GetCommand.cs
+++ b/MSStore.CLI/Commands/Submission/GetCommand.cs
@@ -115,7 +115,7 @@ namespace MSStore.CLI.Commands.Submission
                     return await _telemetryClient.TrackCommandEventAsync<Handler>(productId, -1, ct);
                 }
 
-                AnsiConsole.WriteLine(JsonSerializer.Serialize(submission, submission.GetType(), SourceGenerationContext.GetCustom(true)));
+                StandardOutput.WriteLine(JsonSerializer.Serialize(submission, submission.GetType(), SourceGenerationContext.GetCustom(true)));
 
                 return await _telemetryClient.TrackCommandEventAsync<Handler>(productId, 0, ct);
             }

--- a/MSStore.CLI/Commands/Submission/GetListingAssetsCommand.cs
+++ b/MSStore.CLI/Commands/Submission/GetListingAssetsCommand.cs
@@ -95,7 +95,7 @@ namespace MSStore.CLI.Commands.Submission
                         var baseListing = listing.Value?.BaseListing;
                         if (baseListing != null)
                         {
-                            AnsiConsole.WriteLine(JsonSerializer.Serialize(baseListing, baseListing.GetType(), SourceGenerationContext.GetCustom(true)));
+                            StandardOutput.WriteLine(JsonSerializer.Serialize(baseListing, baseListing.GetType(), SourceGenerationContext.GetCustom(true)));
                         }
                     }
 
@@ -103,7 +103,7 @@ namespace MSStore.CLI.Commands.Submission
                 }
                 else if (ret is ListingAssetsResponse draft)
                 {
-                    AnsiConsole.WriteLine(JsonSerializer.Serialize(draft, draft.GetType(), SourceGenerationContext.GetCustom(true)));
+                    StandardOutput.WriteLine(JsonSerializer.Serialize(draft, draft.GetType(), SourceGenerationContext.GetCustom(true)));
                     return await _telemetryClient.TrackCommandEventAsync<Handler>(0, ct);
                 }
 

--- a/MSStore.CLI/Commands/Submission/Rollout/FinalizeCommand.cs
+++ b/MSStore.CLI/Commands/Submission/Rollout/FinalizeCommand.cs
@@ -99,7 +99,7 @@ namespace MSStore.CLI.Commands.Submission.Rollout
                     return await _telemetryClient.TrackCommandEventAsync<Handler>(productId, -1, ct);
                 }
 
-                AnsiConsole.WriteLine(JsonSerializer.Serialize(submissionRollout, SourceGenerationContext.GetCustom(true).PackageRollout));
+                StandardOutput.WriteLine(JsonSerializer.Serialize(submissionRollout, SourceGenerationContext.GetCustom(true).PackageRollout));
 
                 return await _telemetryClient.TrackCommandEventAsync<Handler>(productId, 0, ct);
             }

--- a/MSStore.CLI/Commands/Submission/Rollout/GetCommand.cs
+++ b/MSStore.CLI/Commands/Submission/Rollout/GetCommand.cs
@@ -109,7 +109,7 @@ namespace MSStore.CLI.Commands.Submission.Rollout
                     return await _telemetryClient.TrackCommandEventAsync<Handler>(productId, -1, ct);
                 }
 
-                AnsiConsole.WriteLine(JsonSerializer.Serialize(submissionRollout, SourceGenerationContext.GetCustom(true).PackageRollout));
+                StandardOutput.WriteLine(JsonSerializer.Serialize(submissionRollout, SourceGenerationContext.GetCustom(true).PackageRollout));
 
                 return await _telemetryClient.TrackCommandEventAsync<Handler>(productId, 0, ct);
             }

--- a/MSStore.CLI/Commands/Submission/Rollout/HaltCommand.cs
+++ b/MSStore.CLI/Commands/Submission/Rollout/HaltCommand.cs
@@ -99,7 +99,7 @@ namespace MSStore.CLI.Commands.Submission.Rollout
                     return await _telemetryClient.TrackCommandEventAsync<Handler>(productId, -1, ct);
                 }
 
-                AnsiConsole.WriteLine(JsonSerializer.Serialize(submissionRollout, SourceGenerationContext.GetCustom(true).PackageRollout));
+                StandardOutput.WriteLine(JsonSerializer.Serialize(submissionRollout, SourceGenerationContext.GetCustom(true).PackageRollout));
 
                 return await _telemetryClient.TrackCommandEventAsync<Handler>(productId, 0, ct);
             }

--- a/MSStore.CLI/Commands/Submission/Rollout/UpdateCommand.cs
+++ b/MSStore.CLI/Commands/Submission/Rollout/UpdateCommand.cs
@@ -117,7 +117,7 @@ namespace MSStore.CLI.Commands.Submission.Rollout
                     return await _telemetryClient.TrackCommandEventAsync<Handler>(productId, -1, ct);
                 }
 
-                AnsiConsole.WriteLine(JsonSerializer.Serialize(submissionRollout, SourceGenerationContext.GetCustom(true).PackageRollout));
+                StandardOutput.WriteLine(JsonSerializer.Serialize(submissionRollout, SourceGenerationContext.GetCustom(true).PackageRollout));
 
                 return await _telemetryClient.TrackCommandEventAsync<Handler>(productId, 0, ct);
             }

--- a/MSStore.CLI/Commands/Submission/StatusCommand.cs
+++ b/MSStore.CLI/Commands/Submission/StatusCommand.cs
@@ -85,7 +85,7 @@ namespace MSStore.CLI.Commands.Submission
                 }
                 else
                 {
-                    AnsiConsole.WriteLine(JsonSerializer.Serialize(status, status.GetType(), SourceGenerationContext.GetCustom(true)));
+                    StandardOutput.WriteLine(JsonSerializer.Serialize(status, status.GetType(), SourceGenerationContext.GetCustom(true)));
                 }
 
                 return await _telemetryClient.TrackCommandEventAsync<Handler>(productId, 0, ct);

--- a/MSStore.CLI/Commands/Submission/UpdateCommand.cs
+++ b/MSStore.CLI/Commands/Submission/UpdateCommand.cs
@@ -165,7 +165,7 @@ namespace MSStore.CLI.Commands.Submission
                     return await _telemetryClient.TrackCommandEventAsync<Handler>(productId, -1, ct);
                 }
 
-                AnsiConsole.WriteLine(JsonSerializer.Serialize(updateSubmissionData, updateSubmissionData.GetType(), SourceGenerationContext.GetCustom(true)));
+                StandardOutput.WriteLine(JsonSerializer.Serialize(updateSubmissionData, updateSubmissionData.GetType(), SourceGenerationContext.GetCustom(true)));
 
                 return await _telemetryClient.TrackCommandEventAsync<Handler>(productId, 0, ct);
             }

--- a/MSStore.CLI/Commands/Submission/UpdateMetadataCommand.cs
+++ b/MSStore.CLI/Commands/Submission/UpdateMetadataCommand.cs
@@ -87,7 +87,7 @@ namespace MSStore.CLI.Commands.Submission
                     return await _telemetryClient.TrackCommandEventAsync<Handler>(productId, -1, ct);
                 }
 
-                AnsiConsole.WriteLine(JsonSerializer.Serialize(updateSubmissionData, updateSubmissionData.GetType(), SourceGenerationContext.GetCustom(true)));
+                StandardOutput.WriteLine(JsonSerializer.Serialize(updateSubmissionData, updateSubmissionData.GetType(), SourceGenerationContext.GetCustom(true)));
 
                 return await _telemetryClient.TrackCommandEventAsync<Handler>(productId, 0, ct);
             }

--- a/MSStore.CLI/Helpers/IProjectConfiguratorExtensions.cs
+++ b/MSStore.CLI/Helpers/IProjectConfiguratorExtensions.cs
@@ -21,10 +21,10 @@ namespace MSStore.CLI.Helpers
                 var defaultImages = ProjectImagesHelper.GetDefaultImagesUsedByApp(ansiConsole, appImages, projectSpecificDefaultImages, imageConverter, logger);
                 if (defaultImages.Count > 0)
                 {
-                    AnsiConsole.MarkupLine($"[bold yellow]The following images are using the default values and should be updated:[/]");
+                    ansiConsole.MarkupLine($"[bold yellow]The following images are using the default values and should be updated:[/]");
                     foreach (var image in defaultImages)
                     {
-                        AnsiConsole.MarkupLine($"[bold yellow]  {image}[/]");
+                        ansiConsole.MarkupLine($"[bold yellow]  {image}[/]");
                     }
                 }
             }

--- a/MSStore.CLI/Helpers/StandardOutput.cs
+++ b/MSStore.CLI/Helpers/StandardOutput.cs
@@ -1,0 +1,25 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+
+namespace MSStore.CLI.Helpers
+{
+    internal static class StandardOutput
+    {
+        /// <summary>
+        /// Writes machine-readable output (JSON payloads, paths) directly to stdout.
+        /// </summary>
+        /// <param name="value">The text to write.</param>
+        /// <remarks>
+        /// This deliberately bypasses Spectre.Console's <see cref="Spectre.Console.AnsiConsole"/>: its renderer
+        /// word-wraps at the console width (falling back to 80 columns when stdout is redirected), which injects
+        /// raw newline characters inside JSON string values and produces invalid JSON.
+        /// </remarks>
+        public static void WriteLine(string value)
+        {
+            Console.Out.WriteLine(value);
+            Console.Out.Flush();
+        }
+    }
+}

--- a/MSStore.CLI/ProjectConfigurators/WinUIProjectConfigurator.cs
+++ b/MSStore.CLI/ProjectConfigurators/WinUIProjectConfigurator.cs
@@ -71,7 +71,7 @@ namespace MSStore.CLI.ProjectConfigurators
 
             version = AppXManifestManager.UpdateManifestVersion(manifestFile.FullName, version);
 
-            var bundleUploadFile = await AnsiConsole.Status().StartAsync("Building MSIX...", async ctx =>
+            var bundleUploadFile = await ErrorAnsiConsole.Status().StartAsync("Building MSIX...", async ctx =>
             {
                 try
                 {


### PR DESCRIPTION
Fixes #150.

## Root cause

`Program.cs` already does the right thing with streams — it creates the DI-injected `IAnsiConsole` over **stderr** (`Out = new AnsiConsoleOutput(Console.Error)`) so all human-facing status text goes to stderr and stdout is reserved for the payload.

But the payload itself was written with Spectre's **static** `AnsiConsole.WriteLine`, which renders the string through Spectre's layout pipeline and **word-wraps at `Profile.Width`**. The wrap knows nothing about JSON, so it injected raw `U+000A`/`U+000D` characters *inside* string values and could split a `\uXXXX` escape in half.

So the stream separation was right; only the renderer was wrong.

Consequences, exactly as reported:

1. The output is not valid JSON — RFC 8259 §7 forbids unescaped control characters in strings.
2. Lenient parsers (PowerShell `ConvertFrom-Json`, `json.loads(strict=False)`) accept it and **silently corrupt the listing text**, so the documented `submission get` → edit → `submission update` round-trip could republish mangled store copy with nothing reporting a problem.
3. Redirected stdout is the *worst* case, not the exempt one: with no console, Spectre falls back to 80 columns — i.e. every CI/scripted run.

This is very likely also the cause of #142: non-Latin listings are dense in `\uXXXX` escapes, so a wrap landing mid-escape produces the reported `\u 04` / bare-backslash errors. I've left that issue open for the reporter to confirm against a real Cyrillic listing.

## Changes

- **New `MSStore.CLI/Helpers/StandardOutput.cs`** — `WriteLine(string)` writes to `Console.Out` directly, with an XML-doc explaining why it must not go through `AnsiConsole`. Only the *write* is wrapped, not the serialization, so there's no new trimming/AOT surface — call sites keep their existing source-generated `JsonSerializer.Serialize(...)` overloads verbatim.
- **19 JSON call sites** across `Commands/{Apps,Flights,Submission}` routed through it.
- **`package`** — the output directory is the command's machine-readable stdout result and had the same bug, so it moves too. That also fixes a latent crash: a path containing `[` currently throws a Spectre markup parse error. ⚠️ Trade-off: the path is no longer green/bold.

### Second commit — keeping `package` stdout actually clean

Self-review turned up that making `package` declare stdout to be its result exposed two *other* writers on that same path still using the static (stdout) console:

- **`WinUIProjectConfigurator.cs:74`** hosted its `"Building MSIX..."` status on the static `AnsiConsole` — the only configurator that did; every sibling uses the injected stderr console, and the block already reported success via `ctx.SuccessStatus(ErrorAnsiConsole, ...)`. When stdout is redirected Spectre selects `FallbackStatusRenderer`, which *writes the description permanently* instead of clearing it, so `Building MSIX...` landed in the piped output ahead of the path.
- **`IProjectConfiguratorExtensions.ValidateImagesAsync`** takes an `IAnsiConsole` and forwards it to `ProjectImagesHelper`, but used the static console for its own two warning lines — so the default-images warning went to stdout.

Both now use the console they already had in hand.

Also switched to **`outputDirectory.FullName`**. `DirectoryInfo.ToString()` returns the original, unnormalised path, and `PWAProjectConfigurator.PackageAsync` returns `new DirectoryInfo(pathOrUrl)` built straight from the command argument — so `msstore package .` emitted a bare `.`, useless to a caller consuming stdout. The other five packagers derive their result from `FileInfo(...).Directory`, which is already absolute, so it's a no-op for them.

### Deliberately not changed

- `apps list` / `flights list` / `info` tables — genuinely rendered views (a `Table` is width-dependent by definition and isn't machine-readable in any format), and `ConsoleReader` / `BrowserLauncher` interactive prompts, which are never on a piped path. These stay on Spectre.
- The `\uXXXX` encoder. Escaped non-ASCII is *valid* JSON; #142's actual failure is the wrap. Switching to `UnsafeRelaxedJsonEscaping` would change the output format for every consumer and belongs in its own change.

## Tests

The harness renders at width 260, so the new tests use a 744-char single-line description sprinkled with characters the serializer escapes as `\uXXXX`.

- `PackagedSubmissionGetCommandShouldNotWrapJsonOutput` and an unpackaged twin (`Submission/GetCommand` has two distinct branches). Each asserts `JsonDocument.Parse(result.Output)` doesn't throw **and** that the description round-trips byte-for-byte — the second assertion is what guards the *silent corruption* case rather than just the parse failure. `JsonDocument.Parse` is itself strong here: it requires stdout to be exactly one JSON value, so it also catches any stray stdout write.
- `PackageCommandUnitTests` now assert `package` writes **exactly one line** to stdout, containing the path. That assertion has teeth — before the second commit the Flutter case emitted three stdout lines.
- `PackageCommandForPWAsShouldPrintAnAbsolutePathForARelativeArgument` (added from review feedback) covers the path-normalization behaviour. `PWAProjectConfigurator` is the only packager that echoes the command argument straight back as its output directory, so it's the one place a relative argument can reach stdout; the test packages via a relative path and asserts stdout equals `Path.GetFullPath(...)` exactly.

Verified the tests catch the bugs they target. Routing `StandardOutput.WriteLine` back through `AnsiConsole` fails both JSON tests with exactly the error from the issue —

```
System.Text.Json.JsonReaderException: '0x0D' is invalid within a JSON string.
The string should be correctly escaped. LineNumber: 11 | BytePositionInLine: 256.
```

— plus 4 `PackageCommand` tests. Reverting `FullName` to `ToString()` fails the PWA test with the strings differing at index 0.

### One test-harness fix was needed

`OutputCapture` called `Console.SetOut(this)` from its **constructor**, which fires for *both* captures — so the error capture silently hijacked `Console.Out`. The bug was invisible while nothing in the product wrote to `Console.Out`. It's now set explicitly, for stdout only, which is also a more faithful model of how `Program.cs` keeps the two streams apart.

## Validation

- `dotnet build MSStore.CLI.sln -c Release` — clean, **0 warnings** (`TreatWarningsAsErrors` is on for Release).
- `net10.0-windows10.0.17763.0`: **141 tests, 0 failed**.
- `net10.0`: 2 failures (`PublishCommandFor{WinUI,Maui}AppsShouldCallMSBuildIfWindows`) — confirmed **pre-existing on the base commit**, unrelated to this change.
- Separately confirmed that `Console.OutputEncoding = Encoding.UTF8` does **not** put a BOM on redirected stdout on .NET 10 (`Console.CreateOutputWriter` strips the preamble), so the piped file starts at `{` and parses strictly.
