### PR TITLE
Allow non-interactive app selection in `init` via `--appId`

### DIFF
--- a/MSStore.CLI.UnitTests/InitCommandUnitTests.cs
+++ b/MSStore.CLI.UnitTests/InitCommandUnitTests.cs
@@ -106,6 +106,46 @@ namespace MSStore.CLI.UnitTests
         }
 
         [TestMethod]
+        public async Task InitCommandShouldAutoSelectOnCIIfAccountHasASingleApp()
+        {
+            AddDefaultFakeAccount();
+            AddFakeApps();
+
+            EnvironmentInformationService
+                .Setup(x => x.IsRunningOnCI)
+                .Returns(true);
+
+            FakeStorePackagedAPI
+                .Setup(x => x.GetApplicationsAsync(It.IsAny<CancellationToken>()))
+                .ReturnsAsync([FakeApps[0]]);
+
+            var result = await ParseAndInvokeAsync(
+                [
+                    "init",
+                    "https://www.microsoft.com/",
+                    "--output",
+                    Path.GetTempPath(),
+                    "--verbose"
+                ]);
+
+            // Asserted piecewise because the app name and id are wrapped in markup,
+            // which becomes ANSI escape sequences when the console supports them.
+            result.Error.Should().Contain(FakeApps[0].PrimaryName!);
+            result.Error.Should().Contain(FakeApps[0].Id!);
+            result.Error.Should().Contain(", the only application registered in your account.");
+            result.Error.Should().NotContain("--appId");
+
+            FakeConsole.Verify(
+                x => x.SelectionPromptAsync(
+                    It.Is<string>(s => s == "Which application should we use to configure your project?"),
+                    It.IsAny<IEnumerable<string>>(),
+                    It.IsAny<int>(),
+                    It.IsAny<Func<string, string>>(),
+                    It.IsAny<CancellationToken>()),
+                Times.Never);
+        }
+
+        [TestMethod]
         public async Task InitCommandShouldFailIfNotOnCIAndPromptIsNotSupported()
         {
             AddDefaultFakeAccount();

--- a/MSStore.CLI.UnitTests/InitCommandUnitTests.cs
+++ b/MSStore.CLI.UnitTests/InitCommandUnitTests.cs
@@ -104,5 +104,41 @@ namespace MSStore.CLI.UnitTests
                     It.IsAny<CancellationToken>()),
                 Times.Never);
         }
+
+        [TestMethod]
+        public async Task InitCommandShouldFailIfNotOnCIAndPromptIsNotSupported()
+        {
+            AddDefaultFakeAccount();
+            AddFakeApps();
+
+            FakeConsole
+                .Setup(x => x.SelectionPromptAsync(
+                    It.Is<string>(s => s == "Which application should we use to configure your project?"),
+                    It.IsAny<IEnumerable<string>>(),
+                    It.IsAny<int>(),
+                    It.IsAny<Func<string, string>>(),
+                    It.IsAny<CancellationToken>()))
+                .ThrowsAsync(new NotSupportedException("Cannot show selection prompt since the current terminal isn't interactive."));
+
+            var result = await ParseAndInvokeAsync(
+                [
+                    "init",
+                    "https://www.microsoft.com/",
+                    "--publish",
+                    "--verbose"
+                ], -1);
+
+            result.Error.Should().Contain("Could not select an application because the current environment is not interactive.");
+            result.Error.Should().Contain("--appId");
+
+            FakeConsole.Verify(
+                x => x.SelectionPromptAsync(
+                    It.Is<string>(s => s == "Which application should we use to configure your project?"),
+                    It.IsAny<IEnumerable<string>>(),
+                    It.IsAny<int>(),
+                    It.IsAny<Func<string, string>>(),
+                    It.IsAny<CancellationToken>()),
+                Times.Once);
+        }
     }
 }

--- a/MSStore.CLI.UnitTests/InitCommandUnitTests.cs
+++ b/MSStore.CLI.UnitTests/InitCommandUnitTests.cs
@@ -40,5 +40,69 @@ namespace MSStore.CLI.UnitTests
 
             BrowserLauncher.Verify(x => x.OpenBrowserAsync("https://partner.microsoft.com/dashboard/registration", true, It.IsAny<CancellationToken>()), Times.Once);
         }
+
+        [TestMethod]
+        public async Task InitCommandShouldFailIfAppIdIsNotFound()
+        {
+            AddDefaultFakeAccount();
+            AddFakeApps();
+
+            FakeStorePackagedAPI
+                .Setup(x => x.GetApplicationAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .ThrowsAsync(new InvalidOperationException("Not found"));
+
+            var result = await ParseAndInvokeAsync(
+                [
+                    "init",
+                    "https://www.microsoft.com/",
+                    "--publish",
+                    "--appId",
+                    "9PN3ABCDEFGZ",
+                    "--verbose"
+                ], -1);
+
+            result.Error.Should().Contain("Could not retrieve your application. Please make sure you have the correct AppId.");
+
+            FakeStorePackagedAPI.Verify(x => x.GetApplicationsAsync(It.IsAny<CancellationToken>()), Times.Never);
+            FakeConsole.Verify(
+                x => x.SelectionPromptAsync(
+                    It.Is<string>(s => s == "Which application should we use to configure your project?"),
+                    It.IsAny<IEnumerable<string>>(),
+                    It.IsAny<int>(),
+                    It.IsAny<Func<string, string>>(),
+                    It.IsAny<CancellationToken>()),
+                Times.Never);
+        }
+
+        [TestMethod]
+        public async Task InitCommandShouldFailOnCIIfNoAppIdIsProvided()
+        {
+            AddDefaultFakeAccount();
+            AddFakeApps();
+
+            EnvironmentInformationService
+                .Setup(x => x.IsRunningOnCI)
+                .Returns(true);
+
+            var result = await ParseAndInvokeAsync(
+                [
+                    "init",
+                    "https://www.microsoft.com/",
+                    "--publish",
+                    "--verbose"
+                ], -1);
+
+            result.Error.Should().Contain("Could not select an application because the current environment is not interactive.");
+            result.Error.Should().Contain("--appId");
+
+            FakeConsole.Verify(
+                x => x.SelectionPromptAsync(
+                    It.Is<string>(s => s == "Which application should we use to configure your project?"),
+                    It.IsAny<IEnumerable<string>>(),
+                    It.IsAny<int>(),
+                    It.IsAny<Func<string, string>>(),
+                    It.IsAny<CancellationToken>()),
+                Times.Never);
+        }
     }
 }

--- a/MSStore.CLI.UnitTests/ProjectConfiguratorTests.cs
+++ b/MSStore.CLI.UnitTests/ProjectConfiguratorTests.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System.Text.RegularExpressions;
+
 using MSStore.CLI.Services.PWABuilder;
 
 namespace MSStore.CLI.UnitTests
@@ -20,12 +22,13 @@ namespace MSStore.CLI.UnitTests
 
         private static (string Output, string Error) CleanResult((string Output, string Error) result)
         {
+            static string Clean(string value) => Regex.Replace(value, @"\x1B\[[0-9;]*[A-Za-z]", string.Empty)
+                .Replace(Environment.NewLine, " ")
+                .Replace("  ", " ");
+
             return (
-                Output: result.Output
-                    .Replace(Environment.NewLine, " ")
-                    .Replace("  ", " "),
-                Error: result.Error.Replace(Environment.NewLine, " ")
-                    .Replace("  ", " "));
+                Output: Clean(result.Output),
+                Error: Clean(result.Error));
         }
 
         [TestMethod]

--- a/MSStore.CLI.UnitTests/ProjectConfiguratorTests.cs
+++ b/MSStore.CLI.UnitTests/ProjectConfiguratorTests.cs
@@ -660,6 +660,8 @@ namespace MSStore.CLI.UnitTests
                     "init",
                     "https://microsoft.com",
                     "--publish",
+                    "--appId",
+                    FakeApps[0].Id!,
                     "--verbose"
                 ]);
 
@@ -723,6 +725,72 @@ namespace MSStore.CLI.UnitTests
 
             result.Error.Should().Contain("You've provided a URL, so we'll use");
             result.Error.Should().Contain("Submission commit success!");
+        }
+
+        [TestMethod]
+        public async Task ProjectConfiguratorParsesPWASuccessfullyOnCIIfAppIdIsProvided()
+        {
+            SetupSuccessfullPWA(true);
+
+            var result = await ParseAndInvokeAsync(
+                [
+                    "init",
+                    "https://microsoft.com",
+                    "--publisherDisplayName",
+                    "FAKE_PUBLISHER_DISPLAY_NAME",
+                    "--publish",
+                    "-id",
+                    FakeApps[1].Id!,
+                    "--verbose"
+                ]);
+
+            result.Error.Should().Contain("You've provided a URL, so we'll use");
+            result.Error.Should().Contain($"AppId: {FakeApps[1].Id}");
+            result.Error.Should().Contain("Submission commit success!");
+
+            FakeStorePackagedAPI.Verify(x => x.GetApplicationsAsync(It.IsAny<CancellationToken>()), Times.Never);
+            FakeConsole.Verify(
+                x => x.SelectionPromptAsync(
+                    It.Is<string>(s => s == "Which application should we use to configure your project?"),
+                    It.IsAny<IEnumerable<string>>(),
+                    It.IsAny<int>(),
+                    It.IsAny<Func<string, string>>(),
+                    It.IsAny<CancellationToken>()),
+                Times.Never);
+        }
+
+        [TestMethod]
+        public async Task ProjectConfiguratorParsesPWASuccessfullyOnCIIfAccountHasASingleApp()
+        {
+            SetupSuccessfullPWA(true);
+
+            FakeStorePackagedAPI
+                .Setup(x => x.GetApplicationsAsync(It.IsAny<CancellationToken>()))
+                .ReturnsAsync([FakeApps[0]]);
+
+            var result = await ParseAndInvokeAsync(
+                [
+                    "init",
+                    "https://microsoft.com",
+                    "--publisherDisplayName",
+                    "FAKE_PUBLISHER_DISPLAY_NAME",
+                    "--publish",
+                    "--verbose"
+                ]);
+
+            result = CleanResult(result);
+
+            result.Error.Should().Contain($"Using {FakeApps[0].PrimaryName} ({FakeApps[0].Id}), the only application registered in your account.");
+            result.Error.Should().Contain("Submission commit success!");
+
+            FakeConsole.Verify(
+                x => x.SelectionPromptAsync(
+                    It.Is<string>(s => s == "Which application should we use to configure your project?"),
+                    It.IsAny<IEnumerable<string>>(),
+                    It.IsAny<int>(),
+                    It.IsAny<Func<string, string>>(),
+                    It.IsAny<CancellationToken>()),
+                Times.Never);
         }
     }
 }

--- a/MSStore.CLI.UnitTests/ProjectConfiguratorTests.cs
+++ b/MSStore.CLI.UnitTests/ProjectConfiguratorTests.cs
@@ -747,6 +747,8 @@ namespace MSStore.CLI.UnitTests
                     "--verbose"
                 ]);
 
+            result = CleanResult(result);
+
             result.Error.Should().Contain("You've provided a URL, so we'll use");
             result.Error.Should().Contain($"AppId: {FakeApps[1].Id}");
             result.Error.Should().Contain("Submission commit success!");

--- a/MSStore.CLI/Commands/InitCommand.cs
+++ b/MSStore.CLI/Commands/InitCommand.cs
@@ -380,6 +380,10 @@ namespace MSStore.CLI.Commands
                         ctx.SuccessStatus(_ansiConsole, "Ok! Found the app!");
                         return app;
                     }
+                    catch (OperationCanceledException) when (ct.IsCancellationRequested)
+                    {
+                        throw;
+                    }
                     catch (Exception err)
                     {
                         ctx.ErrorStatus(_ansiConsole, "Could not retrieve your application. Please make sure you have the correct AppId.");

--- a/MSStore.CLI/Commands/InitCommand.cs
+++ b/MSStore.CLI/Commands/InitCommand.cs
@@ -28,6 +28,7 @@ namespace MSStore.CLI.Commands
     {
         internal static readonly Argument<string> PathOrUrlArgument;
         private static readonly Option<string> PublisherDisplayNameOption;
+        private static readonly Option<string> AppIdOption;
         private static readonly Option<bool> PackageOption;
         private static readonly Option<bool> PublishOption;
         internal static readonly Option<DirectoryInfo?> OutputOption;
@@ -78,6 +79,11 @@ namespace MSStore.CLI.Commands
                 Description = "The Publisher Display Name used to configure the application. If provided, avoids an extra APIs call."
             };
 
+            AppIdOption = new Option<string>("--appId", "-id")
+            {
+                Description = "Specifies the Application Id to configure the project with. If not provided, the application will be selected interactively, which is not possible on CI/CD environments."
+            };
+
             PackageOption = new Option<bool>("--package")
             {
                 Description = "If supported by the app type, automatically packs the project."
@@ -121,6 +127,7 @@ namespace MSStore.CLI.Commands
         {
             Arguments.Add(PathOrUrlArgument);
             Options.Add(PublisherDisplayNameOption);
+            Options.Add(AppIdOption);
             Options.Add(PackageOption);
             Options.Add(PublishOption);
             Options.Add(PublishCommand.FlightIdOption);
@@ -141,6 +148,7 @@ namespace MSStore.CLI.Commands
             IPartnerCenterManager partnerCenterManager,
             IImageConverter imageConverter,
             IConfigurationManager<Configurations> configurationManager,
+            IEnvironmentInformationService environmentInformationService,
             IAnsiConsole ansiConsole,
             TelemetryClient telemetryClient) : AsynchronousCommandLineAction
         {
@@ -153,6 +161,7 @@ namespace MSStore.CLI.Commands
             private readonly IPartnerCenterManager _partnerCenterManager = partnerCenterManager ?? throw new ArgumentNullException(nameof(partnerCenterManager));
             private readonly IImageConverter _imageConverter = imageConverter ?? throw new ArgumentNullException(nameof(imageConverter));
             private readonly IConfigurationManager<Configurations> _configurationManager = configurationManager ?? throw new ArgumentNullException(nameof(configurationManager));
+            private readonly IEnvironmentInformationService _environmentInformationService = environmentInformationService ?? throw new ArgumentNullException(nameof(environmentInformationService));
             private readonly IAnsiConsole _ansiConsole = ansiConsole ?? throw new ArgumentNullException(nameof(ansiConsole));
             private readonly TelemetryClient _telemetryClient = telemetryClient ?? throw new ArgumentNullException(nameof(telemetryClient));
 
@@ -160,6 +169,7 @@ namespace MSStore.CLI.Commands
             {
                 var pathOrUrl = parseResult.GetRequiredValue(PathOrUrlArgument);
                 var publisherDisplayName = parseResult.GetValue(PublisherDisplayNameOption);
+                var appId = parseResult.GetValue(AppIdOption);
                 var package = parseResult.GetValue(PackageOption);
                 var publish = parseResult.GetValue(PublishOption);
                 var flightId = parseResult.GetValue(PublishCommand.FlightIdOption);
@@ -175,6 +185,9 @@ namespace MSStore.CLI.Commands
                 {
                     {
                         "withPDN", (publisherDisplayName != null).ToString()
+                    },
+                    {
+                        "withAppId", (!string.IsNullOrEmpty(appId)).ToString()
                     },
                     {
                         "Package", (package == true).ToString()
@@ -273,7 +286,9 @@ namespace MSStore.CLI.Commands
 
                 var storePackagedAPI = await _storeAPIFactory.CreatePackagedAsync(ct: ct);
 
-                var app = await SelectAppAsync(storePackagedAPI, ct);
+                var app = string.IsNullOrEmpty(appId)
+                    ? await SelectAppAsync(storePackagedAPI, ct)
+                    : await GetAppByIdAsync(storePackagedAPI, appId, ct);
                 if (app == null || string.IsNullOrEmpty(app.Id))
                 {
                     return await _telemetryClient.TrackCommandEventAsync<Handler>(-1, props, ct);
@@ -354,6 +369,26 @@ namespace MSStore.CLI.Commands
                 return await _telemetryClient.TrackCommandEventAsync<Handler>(result, props, ct);
             }
 
+            private async Task<DevCenterApplication?> GetAppByIdAsync(IStorePackagedAPI storePackagedAPI, string appId, CancellationToken ct)
+            {
+                return await _ansiConsole.Status().StartAsync("Retrieving application...", async ctx =>
+                {
+                    try
+                    {
+                        var app = await storePackagedAPI.GetApplicationAsync(appId, ct);
+
+                        ctx.SuccessStatus(_ansiConsole, "Ok! Found the app!");
+                        return app;
+                    }
+                    catch (Exception err)
+                    {
+                        ctx.ErrorStatus(_ansiConsole, "Could not retrieve your application. Please make sure you have the correct AppId.");
+                        _logger.LogError(err, "Could not find application with id '{AppId}'.", appId);
+                        return null;
+                    }
+                });
+            }
+
             private async Task<DevCenterApplication?> SelectAppAsync(IStorePackagedAPI storePackagedAPI, CancellationToken ct)
             {
                 var appList = await GetAppListAsync(storePackagedAPI, ct);
@@ -370,6 +405,19 @@ namespace MSStore.CLI.Commands
                     return await CreateNewAppAsync(ct);
                 }
 
+                if (_environmentInformationService.IsRunningOnCI)
+                {
+                    if (appList.Count == 1)
+                    {
+                        var singleApp = appList[0];
+                        _ansiConsole.MarkupLine($"Using [green bold]{singleApp.PrimaryName?.EscapeMarkup()}[/] ([green bold]{singleApp.Id}[/]), the only application registered in your account.");
+                        return singleApp;
+                    }
+
+                    WriteNonInteractiveError();
+                    return null;
+                }
+
                 var newAppOption = "Create a new app...";
 
                 var appNames = appList.Select(app => app.PrimaryName!).ToList();
@@ -378,14 +426,32 @@ namespace MSStore.CLI.Commands
                 appNames.Add(newAppOption);
                 */
 
-                var selectedApp = await _consoleReader.SelectionPromptAsync(
-                    "Which application should we use to configure your project?",
-                    appNames,
-                    ct: ct);
+                string selectedApp;
+                try
+                {
+                    selectedApp = await _consoleReader.SelectionPromptAsync(
+                        "Which application should we use to configure your project?",
+                        appNames,
+                        ct: ct);
+                }
+                catch (NotSupportedException err)
+                {
+                    _logger.LogError(err, "Could not show the application selection prompt.");
+                    WriteNonInteractiveError();
+                    return null;
+                }
 
                 return selectedApp == newAppOption
                     ? await CreateNewAppAsync(ct)
                     : appList.FirstOrDefault(app => app.PrimaryName == selectedApp);
+            }
+
+            private void WriteNonInteractiveError()
+            {
+                _ansiConsole.MarkupLine(":collision: [bold red]Could not select an application because the current environment is not interactive.[/]");
+                _ansiConsole.MarkupLine("Use the '[bold]--appId[/]' option to specify which application should be used, for example: '[bold]msstore init <pathOrUrl> --appId 9PXXXXXXXXXX[/]'.");
+                _ansiConsole.MarkupLine("You can list the applications registered in your account with '[bold]msstore apps list[/]'.");
+                _logger.LogError("Could not select an application because the current environment is not interactive. Use the '--appId' option to specify which application should be used.");
             }
 
             private Task<DevCenterApplication?> CreateNewAppAsync(CancellationToken ct)

--- a/MSStore.CLI/Commands/InitCommand.cs
+++ b/MSStore.CLI/Commands/InitCommand.cs
@@ -81,7 +81,7 @@ namespace MSStore.CLI.Commands
 
             AppIdOption = new Option<string>("--appId", "-id")
             {
-                Description = "Specifies the Application Id to configure the project with. If not provided, the application will be selected interactively, which is not possible on CI/CD environments."
+                Description = "Specifies the Application Id to configure the project with. If not provided, the application is selected interactively, which is not possible on CI/CD environments, unless the account has a single application."
             };
 
             PackageOption = new Option<bool>("--package")


### PR DESCRIPTION
## Why

`msstore init` is the only command that produces the artifacts a PWA publish needs: it calls the PWABuilder API to build the MSIX bundle (`*_PWABuilderExtractedBundle`) and writes `pwaAppInfo.json`. That makes it mandatory for the PWA publishing flow, since `msstore publish <url> --appId <id>` on its own fails while loading `pwaAppInfo.json`.

But `init` always showed an interactive app-selection prompt, and there was no way to supply the Store Id up front. On a headless runner that prompt throws:

```
Cannot show selection prompt since the current terminal isn't interactive.
```

Net result: a PWA could not be published to the Microsoft Store from GitHub Actions or Azure DevOps at all, even though the Store Id is already known because it was reserved in Partner Center.

## Approach

Three changes, all contained in `InitCommand`:

- **New `--appId` / `-id` option.** When supplied, the app is resolved with `GetApplicationAsync` and `SelectAppAsync` is skipped entirely. Named to match the `--appId`/`-id` option `publish` already has, rather than the `--app-id` spelling suggested in the issue, so it stays consistent with the rest of the CLI's camelCase options.
- **Auto-select when the account has exactly one app**, but only when running non-interactively. Interactive runs keep prompting so behavior there is unchanged.
- **Fail fast with an actionable message** when running non-interactively with more than one app and no `--appId`, instead of letting Spectre throw its generic error:

  ```
  Could not select an application because the current environment is not interactive.
  Use the '--appId' option to specify which application should be used, for example: 'msstore init <pathOrUrl> --appId 9PXXXXXXXXXX'.
  You can list the applications registered in your account with 'msstore apps list'.
  ```

The issue's repro now works end to end:

```
msstore init "https://my.pwa.example" --publish --publisherDisplayName "My Publisher" --appId 9PXXXXXXXXXX
```

## Notes for reviewers

**Non-interactive detection reuses `IEnvironmentInformationService.IsRunningOnCI`** (`CI=true` for GitHub Actions, `TF_BUILD=true` for Azure DevOps) rather than `IAnsiConsole.Profile.Capabilities.Interactive`. This is deliberate: it is already the established "don't prompt" signal in this codebase, used the same way in `FulfillApplicationAsync` to default the category and listings on CI. It is also the only workable option for tests, since every console in `BaseCommandLineTest` is created with `InteractionSupport.No`, so keying off the console capability would have silently broken every existing prompt-based test.

As a secondary safety net, the prompt call is guarded against `NotSupportedException` so a non-TTY that is not flagged as CI gets the same actionable message. Spectre raises that exception for both non-interactive and non-ANSI terminals, and `CreateNewAppAsync` (which throws `NotImplementedException`) sits outside the `try`, so nothing unrelated is swallowed.

**One behavior change worth a look:** on CI with more than one app, `init` now fails fast instead of prompting. That is what previously crashed anyway, so it is strictly an improvement, but it does mean an interactive shell with `CI=true` set will no longer prompt. This matches the existing contract that `IsRunningOnCI` means "do not prompt".

`ProjectConfiguratorParsesPWASuccessfullyIfOnCIIfPublish` was updated to pass `--appId`, reflecting the new requirement that CI runs identify the app.

## Out of scope

Making `publish <url> --appId <id>` work standalone without a prior `init` is a much larger change, since PWA packaging lives in `PWAProjectConfigurator.ConfigureAsync`, which is what calls PWABuilder and writes `pwaAppInfo.json`. The issue's own proposed fix is the `init` option, so `publish` remains init-dependent here.

`--publisherDisplayName` is not a CI blocker and is left alone; it already has non-interactive escape hatches via the flag itself and `msstore settings setpdn`.

## Testing

Five new tests plus one updated:

- `init` with an unknown `--appId` returns -1 with the "Could not retrieve your application" message, and never falls back to listing apps.
- CI with multiple apps and no `--appId` returns -1 with a message mentioning `--appId`.
- PWA end to end on CI with `-id` publishes successfully with no prompt (the exact scenario from the issue, and it covers the short alias).
- CI with a single app auto-selects it and still commits the submission.

Release build (warnings as errors): 0 warnings, 0 errors. Targeted tests: 24/24 passing on both `net10.0` and `net10.0-windows10.0.17763.0`. Two pre-existing `PublishCommandUnitTests` arm64 failures were confirmed unrelated by re-running them on a clean tree.

Fixes: #146