### PR TITLE
Allow submission payloads to be provided by file or standard input

### DIFF
--- a/MSStore.CLI.UnitTests/BaseCommandLineTest.cs
+++ b/MSStore.CLI.UnitTests/BaseCommandLineTest.cs
@@ -127,6 +127,36 @@ namespace MSStore.CLI.UnitTests
             }
         }
 
+        private readonly List<string> _temporaryPayloadFiles = [];
+
+        /// <summary>
+        /// Writes a payload to a temporary file, so that it can be provided to a command either
+        /// through the '--payload' option or as a file path argument. The file is deleted once the
+        /// test finishes.
+        /// </summary>
+        /// <returns>The path of the temporary file.</returns>
+        protected string CreateTemporaryPayloadFile(string payload, [CallerMemberName] string caller = null!)
+        {
+            var path = Path.Combine(Path.GetTempPath(), $"{caller}-{Guid.NewGuid():N}.json");
+
+            File.WriteAllText(path, payload);
+
+            _temporaryPayloadFiles.Add(path);
+
+            return path;
+        }
+
+        [TestCleanup]
+        public void Cleanup()
+        {
+            foreach (var temporaryPayloadFile in _temporaryPayloadFiles)
+            {
+                File.Delete(temporaryPayloadFile);
+            }
+
+            _temporaryPayloadFiles.Clear();
+        }
+
         [TestInitialize]
         public void Initialize()
         {

--- a/MSStore.CLI.UnitTests/FlightsSubmissionCommandUnitTests.cs
+++ b/MSStore.CLI.UnitTests/FlightsSubmissionCommandUnitTests.cs
@@ -100,6 +100,65 @@ namespace MSStore.CLI.UnitTests
         }
 
         [TestMethod]
+        public async Task PackagedFlightSubmissionUpdateCommandWithPayloadOption()
+        {
+            var payloadFilePath = CreateTemporaryPayloadFile(
+                @"
+{
+""FlightPackages"":
+    [
+        {
+            ""FileName"":""C:\\temp\\installer.msix""
+        }
+    ]
+}");
+
+            var result = await ParseAndInvokeAsync(
+                [
+                    "flights",
+                    "submission",
+                    "update",
+                    FakeApps[0].Id!,
+                    FakeFlights[0].FlightId!,
+                    "--payload",
+                    payloadFilePath
+                ]);
+
+            result.Error.Should().Contain("Updating flight submission product");
+            result.Output.Should().Contain("\"FileUploadUrl\": \"https://azureblob.com/fileupload\"");
+        }
+
+        [TestMethod]
+        public async Task PackagedFlightSubmissionUpdateCommandWithStandardInputArgument()
+        {
+            FakeConsole
+                .Setup(x => x.ReadAllStandardInputAsync(null, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(
+                    @"
+{
+""FlightPackages"":
+    [
+        {
+            ""FileName"":""C:\\temp\\installer.msix""
+        }
+    ]
+}");
+
+            var result = await ParseAndInvokeAsync(
+                [
+                    "flights",
+                    "submission",
+                    "update",
+                    FakeApps[0].Id!,
+                    FakeFlights[0].FlightId!,
+                    "-"
+                ]);
+
+            result.Error.Should().Contain("Updating flight submission product");
+            result.Output.Should().Contain("\"FileUploadUrl\": \"https://azureblob.com/fileupload\"");
+        }
+
+        [TestMethod]
         public async Task PackagedFlightSubmissionPublishCommand()
         {
             FakeFlights[0].PendingFlightSubmission = new ApplicationSubmissionInfo

--- a/MSStore.CLI.UnitTests/SubmissionCommandPackagedUnitTests.cs
+++ b/MSStore.CLI.UnitTests/SubmissionCommandPackagedUnitTests.cs
@@ -110,6 +110,214 @@ namespace MSStore.CLI.UnitTests
         }
 
         [TestMethod]
+        public async Task PackagedSubmissionUpdateCommandWithPayloadOption()
+        {
+            var payloadFilePath = CreateTemporaryPayloadFile(
+                @"
+{
+""ApplicationPackages"":
+    [
+        {
+            ""FileName"":""C:\\temp\\installer.msix""
+        }
+    ]
+}");
+
+            var result = await ParseAndInvokeAsync(
+                [
+                    "submission",
+                    "update",
+                    FakeApps[0].Id!,
+                    "--payload",
+                    payloadFilePath
+                ]);
+
+            result.Error.Should().Contain("Updating submission product");
+            result.Output.Should().Contain("\"FileUploadUrl\": \"https://azureblob.com/fileupload\"");
+        }
+
+        [TestMethod]
+        public async Task PackagedSubmissionUpdateCommandWithFilePathArgument()
+        {
+            var payloadFilePath = CreateTemporaryPayloadFile(
+                @"
+{
+""ApplicationPackages"":
+    [
+        {
+            ""FileName"":""C:\\temp\\installer.msix""
+        }
+    ]
+}");
+
+            var result = await ParseAndInvokeAsync(
+                [
+                    "submission",
+                    "update",
+                    FakeApps[0].Id!,
+                    payloadFilePath
+                ]);
+
+            result.Error.Should().Contain("Updating submission product");
+            result.Output.Should().Contain("\"FileUploadUrl\": \"https://azureblob.com/fileupload\"");
+        }
+
+        [TestMethod]
+        public async Task PackagedSubmissionUpdateCommandWithStandardInputArgument()
+        {
+            FakeConsole
+                .Setup(x => x.ReadAllStandardInputAsync(null, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(
+                    @"
+{
+""ApplicationPackages"":
+    [
+        {
+            ""FileName"":""C:\\temp\\installer.msix""
+        }
+    ]
+}");
+
+            var result = await ParseAndInvokeAsync(
+                [
+                    "submission",
+                    "update",
+                    FakeApps[0].Id!,
+                    "-"
+                ]);
+
+            result.Error.Should().Contain("Updating submission product");
+            result.Output.Should().Contain("\"FileUploadUrl\": \"https://azureblob.com/fileupload\"");
+        }
+
+        [TestMethod]
+        public async Task PackagedSubmissionUpdateCommandWithRedirectedStandardInput()
+        {
+            FakeConsole
+                .Setup(x => x.IsInputRedirected)
+                .Returns(true);
+            FakeConsole
+                .Setup(x => x.ReadAllStandardInputAsync(It.IsAny<TimeSpan?>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(
+                    @"
+{
+""ApplicationPackages"":
+    [
+        {
+            ""FileName"":""C:\\temp\\installer.msix""
+        }
+    ]
+}");
+
+            var result = await ParseAndInvokeAsync(
+                [
+                    "submission",
+                    "update",
+                    FakeApps[0].Id!
+                ]);
+
+            result.Error.Should().Contain("Updating submission product");
+            result.Output.Should().Contain("\"FileUploadUrl\": \"https://azureblob.com/fileupload\"");
+        }
+
+        [TestMethod]
+        public async Task PackagedSubmissionUpdateCommandWithNoPayload()
+        {
+            var result = await ParseAndInvokeAsync(
+                [
+                    "submission",
+                    "update",
+                    FakeApps[0].Id!
+                ], 1);
+
+            result.Error.Should().Contain("No 'product' was provided.");
+        }
+
+        [TestMethod]
+        public async Task PackagedSubmissionUpdateCommandWithUnknownFilePath()
+        {
+            var result = await ParseAndInvokeAsync(
+                [
+                    "submission",
+                    "update",
+                    FakeApps[0].Id!,
+                    "this-file-does-not-exist.json"
+                ], 1);
+
+            result.Error.Should().Contain("is neither a JSON payload nor a path to an existing file");
+        }
+
+        [TestMethod]
+        public async Task PackagedSubmissionUpdateCommandWithBothInlineJsonAndPayloadOption()
+        {
+            var payloadFilePath = CreateTemporaryPayloadFile(
+                @"
+{
+""ApplicationPackages"":
+    [
+        {
+            ""FileName"":""C:\\temp\\installer.msix""
+        }
+    ]
+}");
+
+            var result = await ParseAndInvokeAsync(
+                [
+                    "submission",
+                    "update",
+                    FakeApps[0].Id!,
+                    @"{ ""ApplicationPackages"": [] }",
+                    "--payload",
+                    payloadFilePath
+                ], 1);
+
+            result.Error.Should().Contain("Use only one of them.");
+        }
+
+        [TestMethod]
+        public async Task PackagedSubmissionUpdateCommandWithPayloadBiggerThanTheCommandLineLimit()
+        {
+            // The maximum command line length on Windows is 32,767 characters, so a payload this
+            // big can only be provided through a file or through the standard input stream.
+            var description = new string('a', 40000);
+
+            var payloadFilePath = CreateTemporaryPayloadFile(
+                @"
+{
+""Listings"":
+    {
+        ""en-us"":
+        {
+            ""BaseListing"":
+            {
+                ""Description"": """ + description + @"""
+            }
+        }
+    }
+}");
+
+            var result = await ParseAndInvokeAsync(
+                [
+                    "submission",
+                    "update",
+                    FakeApps[0].Id!,
+                    "--payload",
+                    payloadFilePath
+                ]);
+
+            FakeStorePackagedAPI.Verify(
+                x => x.UpdateSubmissionAsync(
+                    It.IsAny<string>(),
+                    It.IsAny<string>(),
+                    It.Is<DevCenterSubmission>(s => s.Listings!["en-us"].BaseListing!.Description == description),
+                    It.IsAny<CancellationToken>()),
+                Times.Once);
+
+            result.Error.Should().Contain("Updating submission product");
+            result.Output.Should().Contain("\"FileUploadUrl\": \"https://azureblob.com/fileupload\"");
+        }
+
+        [TestMethod]
         public async Task PackagedSubmissionUpdateMetadataCommand()
         {
             var result = await ParseAndInvokeAsync(
@@ -130,6 +338,37 @@ namespace MSStore.CLI.UnitTests
         }
     }
 }"
+                ]);
+
+            result.Error.Should().Contain("Updating submission product");
+            result.Output.Should().Contain("\"FileUploadUrl\": \"https://azureblob.com/fileupload\"");
+        }
+
+        [TestMethod]
+        public async Task PackagedSubmissionUpdateMetadataCommandWithPayloadOption()
+        {
+            var payloadFilePath = CreateTemporaryPayloadFile(
+                @"
+{
+""Listings"":
+    {
+        ""en-us"":
+        {
+            ""BaseListing"":
+            {
+                ""Description"": ""New description""
+            }
+        }
+    }
+}");
+
+            var result = await ParseAndInvokeAsync(
+                [
+                    "submission",
+                    "updateMetadata",
+                    FakeApps[0].Id!,
+                    "-p",
+                    payloadFilePath
                 ]);
 
             result.Error.Should().Contain("Updating submission product");

--- a/MSStore.CLI.UnitTests/SubmissionCommandUnpackagedUnitTests.cs
+++ b/MSStore.CLI.UnitTests/SubmissionCommandUnpackagedUnitTests.cs
@@ -141,6 +141,42 @@ namespace MSStore.CLI.UnitTests
         }
 
         [TestMethod]
+        public async Task UnpackagedSubmissionUpdateCommandWithPayloadOption()
+        {
+            FakeStoreAPI
+                .Setup(x => x.UpdateProductPackagesAsync(It.IsAny<string>(), It.IsAny<UpdatePackagesRequest>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new UpdateMetadataResponse
+                {
+                    OngoingSubmissionId = "12345",
+                    PollingUrl = "https://www.example.com/polling"
+                });
+
+            var payloadFilePath = CreateTemporaryPayloadFile(
+                @"
+{
+""Packages"":
+    [
+        {
+            ""PackageUrl"":""https://www.example.com/installer.exe""
+        }
+    ]
+}");
+
+            var result = await ParseAndInvokeAsync(
+                [
+                    "submission",
+                    "update",
+                    Guid.Empty.ToString(),
+                    "--payload",
+                    payloadFilePath
+                ]);
+
+            result.Error.Should().Contain("Updating submission product");
+            result.Output.Should().Contain("\"PollingUrl\": \"https://www.example.com/polling\"");
+            result.Output.Should().Contain("\"OngoingSubmissionId\": \"12345\"");
+        }
+
+        [TestMethod]
         public async Task UnpackagedSubmissionUpdateMetadataCommand()
         {
             FakeStoreAPI
@@ -163,6 +199,41 @@ namespace MSStore.CLI.UnitTests
         ""Pricing"":""1""
     }
 }"
+                ]);
+
+            result.Error.Should().Contain("Updating submission metadata");
+            result.Output.Should().Contain("\"PollingUrl\": \"https://www.example.com/polling\"");
+            result.Output.Should().Contain("\"OngoingSubmissionId\": \"12345\"");
+        }
+
+        [TestMethod]
+        public async Task UnpackagedSubmissionUpdateMetadataCommandWithStandardInput()
+        {
+            FakeStoreAPI
+                .Setup(x => x.UpdateSubmissionMetadataAsync(It.IsAny<string>(), It.IsAny<UpdateMetadataRequest>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new UpdateMetadataResponse
+                {
+                    OngoingSubmissionId = "12345",
+                    PollingUrl = "https://www.example.com/polling"
+                });
+
+            FakeConsole
+                .Setup(x => x.ReadAllStandardInputAsync(null, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(
+                    @"
+{
+""Availability"":
+    {
+        ""Pricing"":""1""
+    }
+}");
+
+            var result = await ParseAndInvokeAsync(
+                [
+                    "submission",
+                    "updateMetadata",
+                    Guid.Empty.ToString(),
+                    "-"
                 ]);
 
             result.Error.Should().Contain("Updating submission metadata");

--- a/MSStore.CLI/Commands/Flights/Submission/UpdateCommand.cs
+++ b/MSStore.CLI/Commands/Flights/Submission/UpdateCommand.cs
@@ -26,7 +26,8 @@ namespace MSStore.CLI.Commands.Flights.Submission
         {
             ProductArgument = new Argument<string>("product")
             {
-                Description = "The updated JSON product representation."
+                Arity = ArgumentArity.ZeroOrOne,
+                Description = "The updated JSON product representation. It can also be the path to a file that contains the JSON, or '-' to read it from the standard input stream."
             };
         }
 
@@ -36,12 +37,14 @@ namespace MSStore.CLI.Commands.Flights.Submission
             Arguments.Add(SubmissionCommand.ProductIdArgument);
             Arguments.Add(Flights.GetCommand.FlightIdArgument);
             Arguments.Add(ProductArgument);
+            Options.Add(SubmissionCommand.PayloadOption);
         }
 
-        public class Handler(ILogger<UpdateCommand.Handler> logger, IStoreAPIFactory storeAPIFactory, IAnsiConsole ansiConsole, TelemetryClient telemetryClient) : AsynchronousCommandLineAction
+        public class Handler(ILogger<UpdateCommand.Handler> logger, IStoreAPIFactory storeAPIFactory, IConsoleReader consoleReader, IAnsiConsole ansiConsole, TelemetryClient telemetryClient) : AsynchronousCommandLineAction
         {
             private readonly ILogger _logger = logger ?? throw new ArgumentNullException(nameof(logger));
             private readonly IStoreAPIFactory _storeAPIFactory = storeAPIFactory ?? throw new ArgumentNullException(nameof(storeAPIFactory));
+            private readonly IConsoleReader _consoleReader = consoleReader ?? throw new ArgumentNullException(nameof(consoleReader));
             private readonly IAnsiConsole _ansiConsole = ansiConsole ?? throw new ArgumentNullException(nameof(ansiConsole));
             private readonly TelemetryClient _telemetryClient = telemetryClient ?? throw new ArgumentNullException(nameof(telemetryClient));
 
@@ -49,13 +52,14 @@ namespace MSStore.CLI.Commands.Flights.Submission
             {
                 var productId = parseResult.GetRequiredValue(SubmissionCommand.ProductIdArgument);
                 var flightId = parseResult.GetRequiredValue(Flights.GetCommand.FlightIdArgument);
-                var product = parseResult.GetRequiredValue(ProductArgument);
 
                 if (ProductTypeHelper.Solve(productId) == ProductType.Unpackaged)
                 {
                     _ansiConsole.WriteLine("This command is not supported for unpackaged applications.");
                     return await _telemetryClient.TrackCommandEventAsync<Handler>(productId, -1, ct);
                 }
+
+                var product = await PayloadResolver.ResolveAsync(_consoleReader, parseResult.GetValue(ProductArgument), parseResult.GetValue(SubmissionCommand.PayloadOption), ProductArgument.Name, ct);
 
                 var updateFlightSubmission = JsonSerializer.Deserialize(product, SourceGenerationContext.GetCustom().DevCenterFlightSubmissionUpdate);
 

--- a/MSStore.CLI/Commands/Submission/UpdateCommand.cs
+++ b/MSStore.CLI/Commands/Submission/UpdateCommand.cs
@@ -26,7 +26,8 @@ namespace MSStore.CLI.Commands.Submission
         {
             ProductArgument = new Argument<string>("product")
             {
-                Description = "The updated JSON product representation."
+                Arity = ArgumentArity.ZeroOrOne,
+                Description = "The updated JSON product representation. It can also be the path to a file that contains the JSON, or '-' to read it from the standard input stream."
             };
         }
 
@@ -35,13 +36,15 @@ namespace MSStore.CLI.Commands.Submission
         {
             Arguments.Add(SubmissionCommand.ProductIdArgument);
             Arguments.Add(ProductArgument);
+            Options.Add(SubmissionCommand.PayloadOption);
             Options.Add(SubmissionCommand.SkipInitialPolling);
         }
 
-        public class Handler(ILogger<UpdateCommand.Handler> logger, IStoreAPIFactory storeAPIFactory, IAnsiConsole ansiConsole, TelemetryClient telemetryClient) : AsynchronousCommandLineAction
+        public class Handler(ILogger<UpdateCommand.Handler> logger, IStoreAPIFactory storeAPIFactory, IConsoleReader consoleReader, IAnsiConsole ansiConsole, TelemetryClient telemetryClient) : AsynchronousCommandLineAction
         {
             private readonly ILogger _logger = logger ?? throw new ArgumentNullException(nameof(logger));
             private readonly IStoreAPIFactory _storeAPIFactory = storeAPIFactory ?? throw new ArgumentNullException(nameof(storeAPIFactory));
+            private readonly IConsoleReader _consoleReader = consoleReader ?? throw new ArgumentNullException(nameof(consoleReader));
             private readonly IAnsiConsole _ansiConsole = ansiConsole ?? throw new ArgumentNullException(nameof(ansiConsole));
             private readonly TelemetryClient _telemetryClient = telemetryClient ?? throw new ArgumentNullException(nameof(telemetryClient));
 
@@ -125,7 +128,7 @@ namespace MSStore.CLI.Commands.Submission
             public override async Task<int> InvokeAsync(ParseResult parseResult, CancellationToken ct = default)
             {
                 var productId = parseResult.GetRequiredValue(SubmissionCommand.ProductIdArgument);
-                var product = parseResult.GetRequiredValue(ProductArgument);
+                var product = await PayloadResolver.ResolveAsync(_consoleReader, parseResult.GetValue(ProductArgument), parseResult.GetValue(SubmissionCommand.PayloadOption), ProductArgument.Name, ct);
                 var skipInitialPolling = parseResult.GetRequiredValue(SubmissionCommand.SkipInitialPolling);
 
                 object? updateSubmissionData = null;

--- a/MSStore.CLI/Commands/Submission/UpdateMetadataCommand.cs
+++ b/MSStore.CLI/Commands/Submission/UpdateMetadataCommand.cs
@@ -25,7 +25,8 @@ namespace MSStore.CLI.Commands.Submission
         {
             MetadataArgument = new Argument<string>("metadata")
             {
-                Description = "The updated JSON metadata representation."
+                Arity = ArgumentArity.ZeroOrOne,
+                Description = "The updated JSON metadata representation. It can also be the path to a file that contains the JSON, or '-' to read it from the standard input stream."
             };
         }
 
@@ -34,20 +35,22 @@ namespace MSStore.CLI.Commands.Submission
         {
             Arguments.Add(SubmissionCommand.ProductIdArgument);
             Arguments.Add(MetadataArgument);
+            Options.Add(SubmissionCommand.PayloadOption);
             Options.Add(SubmissionCommand.SkipInitialPolling);
         }
 
-        public class Handler(ILogger<UpdateMetadataCommand.Handler> logger, IStoreAPIFactory storeAPIFactory, IAnsiConsole ansiConsole, TelemetryClient telemetryClient) : AsynchronousCommandLineAction
+        public class Handler(ILogger<UpdateMetadataCommand.Handler> logger, IStoreAPIFactory storeAPIFactory, IConsoleReader consoleReader, IAnsiConsole ansiConsole, TelemetryClient telemetryClient) : AsynchronousCommandLineAction
         {
             private readonly ILogger _logger = logger ?? throw new ArgumentNullException(nameof(logger));
             private readonly IStoreAPIFactory _storeAPIFactory = storeAPIFactory ?? throw new ArgumentNullException(nameof(storeAPIFactory));
+            private readonly IConsoleReader _consoleReader = consoleReader ?? throw new ArgumentNullException(nameof(consoleReader));
             private readonly IAnsiConsole _ansiConsole = ansiConsole ?? throw new ArgumentNullException(nameof(ansiConsole));
             private readonly TelemetryClient _telemetryClient = telemetryClient ?? throw new ArgumentNullException(nameof(telemetryClient));
 
             public override async Task<int> InvokeAsync(ParseResult parseResult, CancellationToken ct = default)
             {
                 var productId = parseResult.GetRequiredValue(SubmissionCommand.ProductIdArgument);
-                var metadata = parseResult.GetRequiredValue(MetadataArgument);
+                var metadata = await PayloadResolver.ResolveAsync(_consoleReader, parseResult.GetValue(MetadataArgument), parseResult.GetValue(SubmissionCommand.PayloadOption), MetadataArgument.Name, ct);
                 var skipInitialPolling = parseResult.GetRequiredValue(SubmissionCommand.SkipInitialPolling);
 
                 object? updateSubmissionData = null;

--- a/MSStore.CLI/Commands/SubmissionCommand.cs
+++ b/MSStore.CLI/Commands/SubmissionCommand.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System.CommandLine;
+using System.IO;
 using MSStore.CLI.Commands.Submission;
 
 namespace MSStore.CLI.Commands
@@ -10,6 +11,7 @@ namespace MSStore.CLI.Commands
     {
         internal static readonly Option<string> LanguageOption;
         internal static readonly Option<bool> SkipInitialPolling;
+        internal static readonly Option<FileInfo> PayloadOption;
         internal static readonly Argument<string> ProductIdArgument;
 
         static SubmissionCommand()
@@ -25,6 +27,11 @@ namespace MSStore.CLI.Commands
                 DefaultValueFactory = _ => false,
                 Description = "Skip the initial polling before executing the action."
             };
+            PayloadOption = new Option<FileInfo>("--payload", "-p")
+            {
+                Description = "The path to a file that contains the JSON payload. Use this instead of passing the JSON inline whenever the payload might exceed the maximum command line length of the operating system."
+            };
+            PayloadOption.AcceptExistingOnly();
             ProductIdArgument = new Argument<string>("productId")
             {
                 Description = "The product ID."

--- a/MSStore.CLI/Helpers/PayloadResolver.cs
+++ b/MSStore.CLI/Helpers/PayloadResolver.cs
@@ -1,0 +1,127 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using MSStore.API;
+using MSStore.CLI.Services;
+
+namespace MSStore.CLI.Helpers
+{
+    /// <summary>
+    /// Resolves the JSON payload of the commands that update a submission.
+    /// </summary>
+    /// <remarks>
+    /// Passing the payload inline is limited by the maximum command line length of the operating
+    /// system (32,767 characters on Windows), which a real store listing can easily exceed, so the
+    /// payload can also be provided through a file or through the standard input stream.
+    /// </remarks>
+    internal static class PayloadResolver
+    {
+        /// <summary>
+        /// The value that, when used in place of the payload argument, means "read the payload from
+        /// the standard input stream".
+        /// </summary>
+        internal const string StandardInputToken = "-";
+
+        /// <summary>
+        /// How long to wait for the standard input stream when the payload was not provided at all.
+        /// The stream can be redirected but never written to, in which case reading it would block
+        /// forever, so the command fails with an actionable message instead. Only the first
+        /// character is subject to this timeout, so a slow producer is never truncated.
+        /// </summary>
+        private static readonly TimeSpan ImplicitStandardInputTimeout = TimeSpan.FromSeconds(5);
+
+        public static async Task<string> ResolveAsync(IConsoleReader consoleReader, string? inlineValue, FileInfo? payloadFile, string argumentName, CancellationToken ct)
+        {
+            ArgumentNullException.ThrowIfNull(consoleReader);
+
+            if (payloadFile != null)
+            {
+                if (!string.IsNullOrWhiteSpace(inlineValue))
+                {
+                    throw new MSStoreException($"Both the '{argumentName}' argument and the '--payload' option were provided. Use only one of them.");
+                }
+
+                return await ReadFileAsync(payloadFile.FullName, ct);
+            }
+
+            if (string.IsNullOrWhiteSpace(inlineValue))
+            {
+                if (!consoleReader.IsInputRedirected)
+                {
+                    throw new MSStoreException(MissingPayloadMessage(argumentName));
+                }
+
+                var standardInput = await consoleReader.ReadAllStandardInputAsync(ImplicitStandardInputTimeout, ct);
+
+                if (string.IsNullOrWhiteSpace(standardInput))
+                {
+                    throw new MSStoreException($"{MissingPayloadMessage(argumentName)} Nothing was written to the standard input stream within {ImplicitStandardInputTimeout.TotalSeconds} seconds. If you are piping the output of a command that takes longer than that to produce it, use '{StandardInputToken}' as the '{argumentName}' argument, which waits indefinitely.");
+                }
+
+                return standardInput;
+            }
+
+            if (inlineValue == StandardInputToken)
+            {
+                var standardInput = await consoleReader.ReadAllStandardInputAsync(null, ct);
+
+                if (string.IsNullOrWhiteSpace(standardInput))
+                {
+                    throw new MSStoreException($"No '{argumentName}' was provided through the standard input stream.");
+                }
+
+                return standardInput;
+            }
+
+            if (LooksLikeJson(inlineValue))
+            {
+                return inlineValue;
+            }
+
+            if (File.Exists(inlineValue))
+            {
+                return await ReadFileAsync(inlineValue, ct);
+            }
+
+            throw new MSStoreException($"The provided '{argumentName}' is neither a JSON payload nor a path to an existing file. {WaysToProvidePayload(argumentName)}");
+        }
+
+        private static async Task<string> ReadFileAsync(string path, CancellationToken ct)
+        {
+            string payload;
+
+            try
+            {
+                payload = await File.ReadAllTextAsync(path, ct);
+            }
+            catch (Exception err) when (err is IOException or UnauthorizedAccessException or NotSupportedException)
+            {
+                throw new MSStoreException($"Could not read the payload file '{path}'.", err);
+            }
+
+            if (string.IsNullOrWhiteSpace(payload))
+            {
+                throw new MSStoreException($"The payload file '{path}' is empty.");
+            }
+
+            return payload;
+        }
+
+        private static bool LooksLikeJson(string value)
+        {
+            var trimmed = value.AsSpan().TrimStart();
+
+            return trimmed.Length > 0 && (trimmed[0] == '{' || trimmed[0] == '[');
+        }
+
+        private static string MissingPayloadMessage(string argumentName) =>
+            $"No '{argumentName}' was provided. {WaysToProvidePayload(argumentName)}";
+
+        private static string WaysToProvidePayload(string argumentName) =>
+            $"Provide it as inline JSON, as a path to a JSON file, through the '--payload' option, or through the standard input stream (by piping it, or by using '{StandardInputToken}' as the '{argumentName}' argument).";
+    }
+}

--- a/MSStore.CLI/Helpers/PayloadResolver.cs
+++ b/MSStore.CLI/Helpers/PayloadResolver.cs
@@ -24,6 +24,15 @@ namespace MSStore.CLI.Helpers
         /// The value that, when used in place of the payload argument, means "read the payload from
         /// the standard input stream".
         /// </summary>
+        /// <remarks>
+        /// Piping the payload already works without this token, but only under
+        /// <see cref="ImplicitStandardInputTimeout"/>, because a payload that was simply omitted
+        /// cannot be told apart from a stream that is redirected but will never be written to.
+        /// Using this token is the user stating that a payload really is coming, which lets the
+        /// CLI wait for it indefinitely. That is what makes
+        /// '<c>msstore submission get &lt;productId&gt; | msstore submission update &lt;productId&gt; -</c>'
+        /// dependable no matter how long the first command takes.
+        /// </remarks>
         internal const string StandardInputToken = "-";
 
         /// <summary>

--- a/MSStore.CLI/Program.cs
+++ b/MSStore.CLI/Program.cs
@@ -4,8 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.CommandLine.Invocation;
-using System.Diagnostics;
-using System.IO;
 using System.Linq;
 using System.Net.Http;
 using System.Net.Http.Headers;
@@ -223,28 +221,6 @@ namespace MSStore.CLI
             IHost host = hostBuilder.Start();
 
             IHostApplicationLifetime lifetime = host.Services.GetRequiredService<IHostApplicationLifetime>();
-
-            var argList = args.ToList();
-
-            if (Console.IsInputRedirected && !Debugger.IsAttached)
-            {
-                try
-                {
-                    using var stream = Console.OpenStandardInput();
-                    using StreamReader reader = new StreamReader(stream);
-                    var x = await reader.ReadToEndAsync().WaitAsync(new CancellationTokenSource(1000).Token);
-                    if (!string.IsNullOrWhiteSpace(x))
-                    {
-                        argList.Add(x);
-                    }
-                }
-                catch (TaskCanceledException)
-                {
-                    // If there is no input, we don't want to wait forever
-                }
-            }
-
-            args = [.. argList];
 
             var storeCLI = host.Services.GetRequiredService<MicrosoftStoreCLI>();
             var parseResult = storeCLI.Parse(args);

--- a/MSStore.CLI/Services/ConsoleReader.cs
+++ b/MSStore.CLI/Services/ConsoleReader.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -12,6 +13,52 @@ namespace MSStore.CLI.Services
 {
     internal class ConsoleReader : IConsoleReader
     {
+        public bool IsInputRedirected => Console.IsInputRedirected;
+
+        public async Task<string?> ReadAllStandardInputAsync(TimeSpan? firstByteTimeout, CancellationToken ct)
+        {
+            ct.ThrowIfCancellationRequested();
+
+            using var stream = Console.OpenStandardInput();
+            using var reader = new StreamReader(stream);
+
+            var buffer = new char[1];
+
+            var firstCharTask = reader.ReadAsync(buffer, 0, 1);
+
+            int read;
+            if (firstByteTimeout.HasValue)
+            {
+                try
+                {
+                    using var timeoutSource = CancellationTokenSource.CreateLinkedTokenSource(ct);
+                    timeoutSource.CancelAfter(firstByteTimeout.Value);
+
+                    read = await firstCharTask.WaitAsync(timeoutSource.Token);
+                }
+                catch (OperationCanceledException) when (!ct.IsCancellationRequested)
+                {
+                    // Standard input is redirected, but nothing was ever written to it.
+                    return null;
+                }
+            }
+            else
+            {
+                read = await firstCharTask.WaitAsync(ct);
+            }
+
+            if (read == 0)
+            {
+                return null;
+            }
+
+            // The producer may be slow (it could be another CLI call doing network requests), so
+            // the remainder is read without any deadline to make sure nothing is truncated.
+            var rest = await reader.ReadToEndAsync(ct);
+
+            return string.Concat(buffer[0].ToString(), rest);
+        }
+
         public async Task<string?> ReadNextAsync(bool hidden, CancellationToken ct)
         {
             ct.ThrowIfCancellationRequested();

--- a/MSStore.CLI/Services/IConsoleReader.cs
+++ b/MSStore.CLI/Services/IConsoleReader.cs
@@ -10,7 +10,27 @@ namespace MSStore.CLI.Services
 {
     internal interface IConsoleReader
     {
+        bool IsInputRedirected { get; }
+
         Task<string?> ReadNextAsync(bool hidden, CancellationToken ct);
+
+        /// <summary>
+        /// Reads the entirety of the standard input stream.
+        /// </summary>
+        /// <param name="firstByteTimeout">
+        /// How long to wait for the first character. Standard input can be redirected but never
+        /// written to (CI agents, non-interactive shells, debuggers), in which case reading would
+        /// block forever. Pass <c>null</c> to wait indefinitely, which is only appropriate when the
+        /// user explicitly asked to read from standard input.
+        /// </param>
+        /// <param name="ct">The cancellation token.</param>
+        /// <returns>
+        /// The full contents of the standard input stream, or <c>null</c> if the first character
+        /// did not arrive within <paramref name="firstByteTimeout"/>. Once the first character
+        /// arrives, the remainder is read to the end of the stream without any deadline.
+        /// </returns>
+        Task<string?> ReadAllStandardInputAsync(TimeSpan? firstByteTimeout, CancellationToken ct);
+
         Task<string> RequestStringAsync(string fieldName, bool hidden, CancellationToken ct);
         Task<bool> YesNoConfirmationAsync(string message, CancellationToken ct);
         Task<T> SelectionPromptAsync<T>(string title, IEnumerable<T> choices, int pageSize = 10, Func<T, string>? displaySelector = null, CancellationToken ct = default)


### PR DESCRIPTION
Fixes #151.

## Problem

The submission JSON was only accepted as a **positional command-line argument**. Windows caps a command line at 32,767 characters (`CreateProcess` `lpCommandLine`), so any listing whose JSON exceeds that could not be updated through the CLI at all — the reporter's 7-language listing is 66,370 characters, roughly 2x the OS limit.

`Program.cs` already slurped standard input and appended it as an extra argv entry (present since the initial commit — it was the original answer to "don't paste 60 KB on the command line"). `ff9c145` capped that read at **1 second** because standard input can be redirected but never closed (CI agents, non-interactive shells, and under a debugger — hence the pre-existing `!Debugger.IsAttached` guard), which made `ReadToEnd()` block forever.

That cap is what makes the documented round-trip fail today: the read is cancelled and **the payload is silently discarded**, so `msstore submission get … | msstore submission update …` breaks whenever the producer takes longer than a second — which a network-backed `submission get` always does.

## What changed

`submission update`, `submission updateMetadata` and `flights submission update` now resolve their payload in this order:

| # | Form | Notes |
| --- | --- | --- |
| 1 | `--payload <file>` / `-p <file>` | New option, validated with `AcceptExistingOnly()` |
| 2 | `-` as the payload argument | Reads all of standard input, waits indefinitely |
| 3 | Inline JSON | **Unchanged** — existing scripts keep working |
| 4 | A path to an existing file | Checked only after the JSON check, so inline payloads are never probed against the filesystem |
| 5 | Payload omitted + standard input redirected | Replaces the old global slurp |

```console
msstore submission update <productId> --payload listing.json
msstore submission update <productId> listing.json
Get-Content -Raw listing.json | msstore submission update <productId> -
msstore submission get <productId> | msstore submission update <productId> -
```

Standard input reading moved out of `Program.cs` and into the commands that actually want a payload, and is now robust: it waits for the **first character** only (5 s on the implicit path, indefinitely for the explicit `-`), then reads to EOF with **no deadline**. That fixes both failure modes at once — no hang when standard input is redirected-but-empty, and no truncation when the producer is slow. Supplying both an inline payload and `--payload` is now an explicit error instead of one silently winning.

## Verification

Behaviour of the real `ConsoleReader` against actual pipes:

| Scenario | Result |
| --- | --- |
| 60,057-char payload piped in (≈2x the OS limit) | Read in full, 8 ms |
| Producer that emits after 3 s, implicit path | Read in full, identical SHA — old code dropped this |
| Producer that emits after 8 s, explicit `-` | Read in full, identical SHA |
| Redirected, held open 20 s with no data | Returns at 5,016 ms with a clear error, no hang |
| Redirected from `NUL` (CI style) | Returns in 5 ms, no hang |

12 new unit tests cover `--payload`, file-path arguments, `-`/standard input, implicit redirected input, both error paths, and a >32,767-character payload asserted end-to-end through the API mock. The existing inline-JSON tests are untouched and still pass, which is the backwards-compatibility guard.

`dotnet build MSStore.CLI.sln` is clean (0 warnings) and the full suite passes on both target frameworks apart from failures that reproduce unchanged on `main` (`PublishCommandFor{WinUI,Maui}AppsShouldCallMSBuildIfWindows` on `net10.0`, and the npm/yarn `PackageCommand` tests on `net10.0-windows`).

## Follow-up

The published reference at `MicrosoftDocs/windows-dev-docs-pr` → `hub/apps/publish/msstore-dev-cli/commands.md` still documents the positional-only syntax and needs a separate docs PR. `--help` is already updated by this change.