### PR TITLE
Fix `--uploadTimeout` defaulting to 0 when the option is omitted

### DIFF
--- a/MSStore.CLI.UnitTests/PublishCommandUnitTests.cs
+++ b/MSStore.CLI.UnitTests/PublishCommandUnitTests.cs
@@ -1,6 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System.CommandLine;
+using System.Globalization;
+using MSStore.CLI.Commands;
 using MSStore.CLI.ProjectConfigurators;
 
 namespace MSStore.CLI.UnitTests
@@ -304,6 +307,57 @@ namespace MSStore.CLI.UnitTests
 
             result.Error.Should().Contain("Submission commit success! Here is some data:");
             result.Error.Should().Contain("test.msix");
+        }
+        private static ParseResult ParsePublish(params string[] args) =>
+            new PublishCommand().Parse(args);
+
+        [TestMethod]
+        public void PublishCommandUploadTimeoutShouldDefaultWhenOptionIsOmitted()
+        {
+            // Regression: without a DefaultValueFactory this returned default(long) - zero - which
+            // reaches BlobClientOptions.Retry.NetworkTimeout and cancels every upload immediately.
+            var parseResult = ParsePublish("publish", ".");
+
+            parseResult
+                .GetValue(PublishCommand.UploadTimeoutOption)
+                .Should()
+                .Be(PublishCommand.DefaultUploadTimeoutSeconds);
+        }
+
+        [TestMethod]
+        public void PublishCommandUploadTimeoutShouldRequireAValueWhenTheOptionIsPresent()
+        {
+            // The option takes exactly one argument, so the CustomParser's "no tokens" branch is
+            // unreachable from the command line - which is why its 100 was never the default that
+            // applied when the option was left out altogether.
+            var parseResult = ParsePublish("publish", ".", "--uploadTimeout");
+
+            parseResult.Errors.Should().NotBeEmpty();
+        }
+
+        [TestMethod]
+        [DataRow(100)]
+        [DataRow(300)]
+        [DataRow(100000)]
+        public void PublishCommandUploadTimeoutShouldUseTheProvidedValue(int seconds)
+        {
+            var parseResult = ParsePublish("publish", ".", "--uploadTimeout", seconds.ToString(CultureInfo.InvariantCulture));
+
+            parseResult
+                .GetValue(PublishCommand.UploadTimeoutOption)
+                .Should()
+                .Be(seconds);
+        }
+
+        [TestMethod]
+        [DataRow("99")]
+        [DataRow("100001")]
+        [DataRow("not-a-number")]
+        public void PublishCommandUploadTimeoutShouldRejectValuesOutsideTheAllowedRange(string seconds)
+        {
+            var parseResult = ParsePublish("publish", ".", "--uploadTimeout", seconds);
+
+            parseResult.Errors.Should().NotBeEmpty();
         }
     }
 }

--- a/MSStore.CLI.UnitTests/PublishCommandUnitTests.cs
+++ b/MSStore.CLI.UnitTests/PublishCommandUnitTests.cs
@@ -327,12 +327,24 @@ namespace MSStore.CLI.UnitTests
         [TestMethod]
         public void PublishCommandUploadTimeoutShouldRequireAValueWhenTheOptionIsPresent()
         {
-            // The option takes exactly one argument, so the CustomParser's "no tokens" branch is
-            // unreachable from the command line - which is why its 100 was never the default that
-            // applied when the option was left out altogether.
+            // The option's arity is ExactlyOne, so a value-less "--uploadTimeout" is rejected by the
+            // parser itself rather than reaching the CustomParser with an empty token list. That is
+            // why the CustomParser carries no "no tokens" branch: omitting the option is served by
+            // DefaultValueFactory, and this is the only other way it could have been entered.
             var parseResult = ParsePublish("publish", ".", "--uploadTimeout");
 
-            parseResult.Errors.Should().NotBeEmpty();
+            // The wording comes from System.CommandLine and is localized, so only the option name is
+            // asserted; what matters is that the error is the parser's own, not the CustomParser's.
+            parseResult
+                .Errors
+                .Should()
+                .ContainSingle()
+                .Which
+                .Message
+                .Should()
+                .Contain("--uploadTimeout")
+                .And
+                .NotContain("The value must be between");
         }
 
         [TestMethod]
@@ -357,7 +369,14 @@ namespace MSStore.CLI.UnitTests
         {
             var parseResult = ParsePublish("publish", ".", "--uploadTimeout", seconds);
 
-            parseResult.Errors.Should().NotBeEmpty();
+            parseResult
+                .Errors
+                .Should()
+                .ContainSingle()
+                .Which
+                .Message
+                .Should()
+                .Be($"Invalid seconds value. The value must be between {PublishCommand.MinUploadTimeoutSeconds} and {PublishCommand.MaxUploadTimeoutSeconds}.");
         }
     }
 }

--- a/MSStore.CLI/Commands/PublishCommand.cs
+++ b/MSStore.CLI/Commands/PublishCommand.cs
@@ -23,8 +23,8 @@ namespace MSStore.CLI.Commands
     {
         internal const long DefaultUploadTimeoutSeconds = 100;
 
-        private const long MinUploadTimeoutSeconds = 100;
-        private const long MaxUploadTimeoutSeconds = 100000;
+        internal const long MinUploadTimeoutSeconds = 100;
+        internal const long MaxUploadTimeoutSeconds = 100000;
 
         internal static readonly Option<string> FlightIdOption;
         internal static readonly Option<float?> PackageRolloutPercentageOption;
@@ -105,18 +105,16 @@ namespace MSStore.CLI.Commands
             {
                 Description = "Specifies timeout in seconds for package upload to blob storage. Valid only for MSIX and PWA packages.",
 
-                // CustomParser only runs when the option is present on the command line. Without a
-                // DefaultValueFactory, omitting the option entirely yields default(long) - zero -
+                // CustomParser never sees an empty token list: the option's arity is ExactlyOne, so
+                // "--uploadTimeout" without a value fails to parse before the parser runs, and an
+                // omitted option is served by DefaultValueFactory below without reaching the parser
+                // at all. Without that factory, omitting the option yielded default(long) - zero -
                 // which reaches BlobClientOptions.Retry.NetworkTimeout and cancels every request
-                // the moment it starts.
+                // the moment it starts. If the arity is ever relaxed to ZeroOrOne, a "no tokens"
+                // branch has to come back here.
                 DefaultValueFactory = _ => DefaultUploadTimeoutSeconds,
                 CustomParser = result =>
                 {
-                    if (result.Tokens.Count == 0)
-                    {
-                        return DefaultUploadTimeoutSeconds;
-                    }
-
                     string? seconds = result.Tokens.Single().Value;
                     if (!long.TryParse(seconds, out long parsedSeconds))
                     {

--- a/MSStore.CLI/Commands/PublishCommand.cs
+++ b/MSStore.CLI/Commands/PublishCommand.cs
@@ -21,6 +21,11 @@ namespace MSStore.CLI.Commands
 {
     internal class PublishCommand : Command
     {
+        internal const long DefaultUploadTimeoutSeconds = 100;
+
+        private const long MinUploadTimeoutSeconds = 100;
+        private const long MaxUploadTimeoutSeconds = 100000;
+
         internal static readonly Option<string> FlightIdOption;
         internal static readonly Option<float?> PackageRolloutPercentageOption;
         internal static readonly Option<long> UploadTimeoutOption;
@@ -99,23 +104,29 @@ namespace MSStore.CLI.Commands
             UploadTimeoutOption = new Option<long>("--uploadTimeout", "-ut")
             {
                 Description = "Specifies timeout in seconds for package upload to blob storage. Valid only for MSIX and PWA packages.",
+
+                // CustomParser only runs when the option is present on the command line. Without a
+                // DefaultValueFactory, omitting the option entirely yields default(long) - zero -
+                // which reaches BlobClientOptions.Retry.NetworkTimeout and cancels every request
+                // the moment it starts.
+                DefaultValueFactory = _ => DefaultUploadTimeoutSeconds,
                 CustomParser = result =>
                 {
                     if (result.Tokens.Count == 0)
                     {
-                        return 100;
+                        return DefaultUploadTimeoutSeconds;
                     }
 
                     string? seconds = result.Tokens.Single().Value;
                     if (!long.TryParse(seconds, out long parsedSeconds))
                     {
-                        result.AddError("Invalid seconds value. The value must be between 100 and 100000.");
-                        return 100;
+                        result.AddError($"Invalid seconds value. The value must be between {MinUploadTimeoutSeconds} and {MaxUploadTimeoutSeconds}.");
+                        return DefaultUploadTimeoutSeconds;
                     }
-                    else if (parsedSeconds < 100 || parsedSeconds > 100000)
+                    else if (parsedSeconds < MinUploadTimeoutSeconds || parsedSeconds > MaxUploadTimeoutSeconds)
                     {
-                        result.AddError("Invalid seconds value. The value must be between 100 and 100000.");
-                        return 100;
+                        result.AddError($"Invalid seconds value. The value must be between {MinUploadTimeoutSeconds} and {MaxUploadTimeoutSeconds}.");
+                        return DefaultUploadTimeoutSeconds;
                     }
                     else
                     {


### PR DESCRIPTION
Fixes #162.

## Problem

`UploadTimeoutOption` declares a `CustomParser` that returns `100` for the empty-token case, but no `DefaultValueFactory`. System.CommandLine only invokes `CustomParser` when the option is **present** on the command line, so omitting it entirely yields `default(long)` — zero.

That zero reaches `AzureBlobManager.UploadFileAsync`:

```csharp
blobClientOptions.Retry.NetworkTimeout = TimeSpan.FromSeconds(uploadTimeout);
```

`TimeSpan.FromSeconds(0)` cancels every request the instant it starts, so `msstore publish` fails at `Uploading Bundle to Azure blob: 0%` after six retries — on every invocation that does not pass `--uploadTimeout` explicitly.

## Fix

Add `DefaultValueFactory = _ => DefaultUploadTimeoutSeconds` so the documented 100-second default applies when the option is absent.

Worth noting: the `CustomParser`'s empty-token branch can never cover that case. The option takes exactly one argument, so writing `--uploadTimeout` without a value is a **parse error**, not an empty-token parse. One of the new tests pins that behaviour so the two paths stay distinguishable.

I also lifted the `100` / `100000` literals into named constants, so the default, the range check and the error message cannot drift apart. Happy to drop that part if you would rather keep the diff to the single line.

## Tests

8 new cases in `PublishCommandUnitTests`:

- the option omitted → 100 (this is the regression)
- the option present without a value → parse error
- `100`, `300`, `100000` → used as given
- `99`, `100001`, `not-a-number` → parse error

**Verified the regression test actually catches the bug**: with the `DefaultValueFactory` line removed, `PublishCommandUploadTimeoutShouldDefaultWhenOptionIsOmitted` fails; with it, all 8 pass.

The suite has 10 pre-existing failures on my machine (MSBuild / WinUI / settings related). They are identical with and without this change — 138 tests / 10 failures before, 146 tests / 10 failures after.

## Why this was hard to spot

The console shows only `Error while uploading the application package.` — the exception goes to `logger.LogError(ex, ...)` while `ansiConsole.WriteLine` gets a bare sentence, so it reads as a network or service problem. The `0:00:00` only appears with `--verbose`. It cost several release runs before that was visible.

A guard rejecting a non-positive `uploadTimeout` in `AzureBlobManager.UploadFileAsync` would make this self-explanatory if it ever regresses. I left it out to keep this focused, but happy to add it.
