### PR TITLE
Fix `--packageRolloutPercentage` being silently ignored

### DIFF
--- a/MSStore.CLI.UnitTests/PublishCommandUnitTests.cs
+++ b/MSStore.CLI.UnitTests/PublishCommandUnitTests.cs
@@ -3,6 +3,7 @@
 
 using System.CommandLine;
 using System.Globalization;
+using MSStore.API.Packaged.Models;
 using MSStore.CLI.Commands;
 using MSStore.CLI.ProjectConfigurators;
 
@@ -308,6 +309,103 @@ namespace MSStore.CLI.UnitTests
             result.Error.Should().Contain("Submission commit success! Here is some data:");
             result.Error.Should().Contain("test.msix");
         }
+
+        [TestMethod]
+        public async Task PublishCommandShouldApplyPackageRolloutPercentageWhenSubmissionHasNoRolloutConfigured()
+        {
+            // Regression: the rollout was only applied when the submission already carried a
+            // PackageDeliveryOptions.PackageRollout object. A newly created submission has neither,
+            // so --packageRolloutPercentage was silently dropped and the app shipped to 100%.
+            var path = CopyFilesRecursively("MSIXProject");
+
+            var msixPath = Path.Combine(path, "test.msix");
+
+            AddDefaultFakeSuccessfulSubmission();
+
+            await ParseAndInvokeAsync(
+                [
+                    "publish",
+                    msixPath,
+                    "--appId",
+                    FakeApps[0].Id!,
+                    "--packageRolloutPercentage",
+                    "5"
+                ]);
+
+            FakeStorePackagedAPI
+                .Verify(
+                    x => x.UpdateSubmissionAsync(
+                        It.IsAny<string>(),
+                        It.IsAny<string>(),
+                        It.Is<DevCenterSubmission>(s =>
+                            s.PackageDeliveryOptions!.PackageRollout!.IsPackageRollout &&
+                            s.PackageDeliveryOptions.PackageRollout.PackageRolloutPercentage == 5),
+                        It.IsAny<CancellationToken>()),
+                    Times.Once);
+        }
+
+        [TestMethod]
+        public async Task PublishCommandShouldApplyPackageRolloutPercentageForFlights()
+        {
+            var path = CopyFilesRecursively("MSIXProject");
+
+            var msixPath = Path.Combine(path, "test.msix");
+
+            AddFakeFlights();
+            AddDefaultFakeSuccessfulFlightSubmission();
+
+            await ParseAndInvokeAsync(
+                [
+                    "publish",
+                    msixPath,
+                    "--appId",
+                    FakeApps[0].Id!,
+                    "--flightId",
+                    FakeFlights[0].FlightId!,
+                    "--packageRolloutPercentage",
+                    "5"
+                ]);
+
+            FakeStorePackagedAPI
+                .Verify(
+                    x => x.UpdateFlightSubmissionAsync(
+                        It.IsAny<string>(),
+                        It.IsAny<string>(),
+                        It.IsAny<string>(),
+                        It.Is<DevCenterFlightSubmissionUpdate>(s =>
+                            s.PackageDeliveryOptions!.PackageRollout!.IsPackageRollout &&
+                            s.PackageDeliveryOptions.PackageRollout.PackageRolloutPercentage == 5),
+                        It.IsAny<CancellationToken>()),
+                    Times.Once);
+        }
+
+        [TestMethod]
+        public async Task PublishCommandShouldNotEnableRolloutWhenPercentageIsNotProvided()
+        {
+            var path = CopyFilesRecursively("MSIXProject");
+
+            var msixPath = Path.Combine(path, "test.msix");
+
+            AddDefaultFakeSuccessfulSubmission();
+
+            await ParseAndInvokeAsync(
+                [
+                    "publish",
+                    msixPath,
+                    "--appId",
+                    FakeApps[0].Id!
+                ]);
+
+            FakeStorePackagedAPI
+                .Verify(
+                    x => x.UpdateSubmissionAsync(
+                        It.IsAny<string>(),
+                        It.IsAny<string>(),
+                        It.Is<DevCenterSubmission>(s => s.PackageDeliveryOptions == null),
+                        It.IsAny<CancellationToken>()),
+                    Times.Once);
+        }
+
         private static ParseResult ParsePublish(params string[] args) =>
             new PublishCommand().Parse(args);
 

--- a/MSStore.CLI/Helpers/IStorePackagedAPIExtensions.cs
+++ b/MSStore.CLI/Helpers/IStorePackagedAPIExtensions.cs
@@ -484,8 +484,13 @@ namespace MSStore.CLI.Helpers
                 return -1;
             }
 
-            if (submission.PackageDeliveryOptions?.PackageRollout != null && packageRolloutPercentage != null)
+            if (packageRolloutPercentage != null)
             {
+                // A freshly created submission usually comes back with no rollout configured at all,
+                // so these objects have to be materialized rather than assumed. Guarding on
+                // PackageRollout being non-null silently dropped --packageRolloutPercentage.
+                submission.PackageDeliveryOptions ??= new PackageDeliveryOptions();
+                submission.PackageDeliveryOptions.PackageRollout ??= new PackageRollout();
                 submission.PackageDeliveryOptions.PackageRollout.IsPackageRollout = true;
                 submission.PackageDeliveryOptions.PackageRollout.PackageRolloutPercentage = packageRolloutPercentage.Value;
             }


### PR DESCRIPTION
## Problem

`msstore publish --packageRolloutPercentage <n>` is silently ignored in the common case, and the package ships to **100% of users** while the caller believes the rollout is staged at `<n>%`.

`PublishAsync` only applied the requested percentage when the submission it had just retrieved *already* carried a `PackageDeliveryOptions.PackageRollout` object:

```csharp
if (submission.PackageDeliveryOptions?.PackageRollout != null && packageRolloutPercentage != null)
{
    submission.PackageDeliveryOptions.PackageRollout.IsPackageRollout = true;
    submission.PackageDeliveryOptions.PackageRollout.PackageRolloutPercentage = packageRolloutPercentage.Value;
}
```

A freshly created submission generally has no rollout configured, so the guard is false exactly when the user asked for a rollout. There is no error, no warning, and no non-zero exit code — the flag just evaporates.

This is a bad failure mode: it fails open, toward the widest possible audience, and it's invisible until telemetry shows the update reached everyone.

## Fix

Materialize the objects when a percentage is supplied, rather than requiring them to pre-exist:

```csharp
if (packageRolloutPercentage != null)
{
    submission.PackageDeliveryOptions ??= new PackageDeliveryOptions();
    submission.PackageDeliveryOptions.PackageRollout ??= new PackageRollout();
    submission.PackageDeliveryOptions.PackageRollout.IsPackageRollout = true;
    submission.PackageDeliveryOptions.PackageRollout.PackageRolloutPercentage = packageRolloutPercentage.Value;
}
```

Both the app and flight paths are covered — the mutation happens before the `DevCenterSubmission` / `DevCenterFlightSubmission` cast, and the flight update already copies `PackageDeliveryOptions` onto `DevCenterFlightSubmissionUpdate`.

Behavior when the option is omitted is unchanged: `packageRolloutPercentage` is `null`, so nothing is allocated and the submission's delivery options are left exactly as the service returned them.

## Tests

Three tests added to `PublishCommandUnitTests`:

| Test | Purpose |
| --- | --- |
| `...ShouldApplyPackageRolloutPercentageWhenSubmissionHasNoRolloutConfigured` | App path — asserts `UpdateSubmissionAsync` receives `IsPackageRollout: true` / `5%` |
| `...ShouldApplyPackageRolloutPercentageForFlights` | Flight path — same assertion on `UpdateFlightSubmissionAsync` |
| `...ShouldNotEnableRolloutWhenPercentageIsNotProvided` | Pins that omitting the option leaves `PackageDeliveryOptions` untouched |

The default fixtures (`AddDefaultFakeSubmission` / `AddDefaultFakeFlightSubmission`) already build submissions with no `PackageDeliveryOptions`, so they reproduce the bug without modification. Verified both new rollout tests **fail on `main` and pass with this change**:

```
Test run summary: Failed! (fix reverted)
  total: 2   failed: 2   succeeded: 0
```

Full suite green on both target frameworks:

```
net10.0                      total: 149  failed: 0  succeeded: 139  skipped: 10
net10.0-windows10.0.17763.0  total: 149  failed: 0  succeeded: 141  skipped: 8
```

## Notes

Reported in #149, where the user hit this while trying to build a flight → metadata → staged-rollout pipeline and concluded rollout was flights-only.

Worth calling out separately: `msstore submission rollout get|update|halt|finalize` already works for non-flighted submissions, but is missing from the [Learn commands page](https://learn.microsoft.com/en-us/windows/apps/publish/msstore-dev-cli/commands), which is what sent that user down the wrong path. That's a docs fix I'll do in `windows-dev-docs`.

Users on the current release can work around this bug by setting `PackageDeliveryOptions.PackageRollout` explicitly in the JSON passed to `msstore submission update`, which is unaffected.