### PR TITLE
Validate reconfigure before mutating the credential store

### DIFF
--- a/MSStore.CLI.UnitTests/BaseCommandLineTest.cs
+++ b/MSStore.CLI.UnitTests/BaseCommandLineTest.cs
@@ -196,7 +196,11 @@ namespace MSStore.CLI.UnitTests
                 .Setup(x => x.ReadCredential(It.IsAny<string>()))
                 .Returns((string userName) =>
                 {
-                    return userName.Equals(UserNames.Last(), StringComparison.OrdinalIgnoreCase) ? Secrets.Last() : string.Empty;
+                    // Mirrors the real implementations, which return an empty string when no credential is
+                    // stored for the user - notably after ClearCredentials has emptied the lists.
+                    return UserNames.Count > 0 && userName.Equals(UserNames.Last(), StringComparison.OrdinalIgnoreCase)
+                        ? Secrets.Last()
+                        : string.Empty;
                 });
             ExternalCommandExecutor = new Mock<IExternalCommandExecutor>();
             FakeConsole = new Mock<IConsoleReader>();

--- a/MSStore.CLI.UnitTests/BaseCommandLineTest.cs
+++ b/MSStore.CLI.UnitTests/BaseCommandLineTest.cs
@@ -226,10 +226,14 @@ namespace MSStore.CLI.UnitTests
                 .Setup(fac => fac.CreateAsync(It.IsAny<Configurations>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(FakeStoreAPI.Object);
             FakeStoreAPIFactory
+                .Setup(fac => fac.CreateWithSecretAsync(It.IsAny<Configurations>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(FakeStoreAPI.Object);
+            FakeStoreAPIFactory
                 .Setup(fac => fac.CreatePackagedAsync(It.IsAny<Configurations>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(FakeStorePackagedAPI.Object);
 
             StorePackagedAPI.DefaultSubmissionPollDelay = TimeSpan.Zero;
+            CLIConfigurator.ValidationRetryDelay = TimeSpan.Zero;
 
             var azureBlobManagerMock = new Mock<IAzureBlobManager>();
             azureBlobManagerMock

--- a/MSStore.CLI.UnitTests/ReconfigureCredentialSafetyUnitTests.cs
+++ b/MSStore.CLI.UnitTests/ReconfigureCredentialSafetyUnitTests.cs
@@ -1,0 +1,225 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using MSStore.API;
+using MSStore.CLI.Services;
+
+namespace MSStore.CLI.UnitTests
+{
+    /// <summary>
+    /// Regression tests for the ordering bug where <c>reconfigure</c> mutated the OS credential store before
+    /// validating the new configuration, so a failed reconfigure could permanently destroy a working client secret.
+    /// </summary>
+    [TestClass]
+    public class ReconfigureCredentialSafetyUnitTests : BaseCommandLineTest
+    {
+        private const string ExistingClientId = "3F0BCAEF-6334-48CF-837F-81CB0F1F2C45";
+        private const string ExistingSecret = "existingWorkingSecret";
+
+        private readonly Dictionary<string, string> _credentialStore = new(StringComparer.OrdinalIgnoreCase);
+        private readonly List<string?> _validationSecrets = [];
+        private readonly List<Dictionary<string, string>> _credentialStoreDuringValidation = [];
+
+        [TestInitialize]
+        [TestCleanup]
+        public void ClearAssertionVars()
+        {
+            Environment.SetEnvironmentVariable("MSSTORE_CLIENT_ASSERTION", null);
+            Environment.SetEnvironmentVariable("MSSTORE_CLIENT_ASSERTION_FILE", null);
+        }
+
+        /// <summary>
+        /// Replaces the list-based credential mock from <see cref="BaseCommandLineTest"/> with a dictionary-backed
+        /// in-memory credential store seeded with a working client secret, so assertions can look at the actual
+        /// state of the store rather than at a call log. Also captures the secret each validation attempt is made
+        /// with, and a snapshot of the store at that moment.
+        /// </summary>
+        private void ArrangeExistingClientSecretConfiguration(bool validationSucceeds)
+        {
+            _credentialStore.Clear();
+            _credentialStore[ExistingClientId] = ExistingSecret;
+
+            CredentialManager.Reset();
+            CredentialManager
+                .Setup(x => x.ReadCredential(It.IsAny<string>()))
+                .Returns((string userName) => _credentialStore.TryGetValue(userName, out var secret) ? secret : string.Empty);
+            CredentialManager
+                .Setup(x => x.WriteCredential(It.IsAny<string>(), It.IsAny<string>()))
+                .Callback((string userName, string secret) => _credentialStore[userName] = secret);
+            CredentialManager
+                .Setup(x => x.ClearCredentials(It.IsAny<string>()))
+                .Callback((string userName) => _credentialStore.Remove(userName));
+
+            FakeStoreAPIFactory
+                .Setup(fac => fac.CreateWithSecretAsync(It.IsAny<Configurations>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+                .Callback((Configurations config, string? secret, CancellationToken ct) =>
+                {
+                    _validationSecrets.Add(secret);
+                    _credentialStoreDuringValidation.Add(new Dictionary<string, string>(_credentialStore, StringComparer.OrdinalIgnoreCase));
+                })
+                .Returns(() => validationSucceeds
+                    ? Task.FromResult(FakeStoreAPI.Object)
+                    : Task.FromException<IStoreAPI>(new InvalidOperationException("Invalid credential")));
+        }
+
+        private Task<(string Output, string Error)> ReconfigureAsync(string[] credentialArgs, int expectedResult)
+        {
+            return ParseAndInvokeAsync(
+                [
+                    "reconfigure",
+                    "--tenantId",
+                    DefaultOrganization.Id!.Value.ToString(),
+                    "--sellerId",
+                    "12345",
+                    "--clientId",
+                    ExistingClientId,
+                    .. credentialArgs
+                ],
+                expectedResult);
+        }
+
+        private void VerifyCredentialStoreWasNotTouched()
+        {
+            _credentialStore.Should().ContainKey(ExistingClientId);
+            _credentialStore[ExistingClientId].Should().Be(ExistingSecret);
+
+            CredentialManager.Verify(x => x.WriteCredential(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+            CredentialManager.Verify(x => x.ClearCredentials(It.IsAny<string>()), Times.Never);
+            FakeConfigurationManager.Verify(x => x.SaveAsync(It.IsAny<Configurations>(), It.IsAny<CancellationToken>()), Times.Never);
+        }
+
+        [TestMethod]
+        public async Task FailedClientAssertionReconfigureShouldNotDestroyExistingClientSecret()
+        {
+            // The exact repro from the issue: a working client-secret configuration switched to client assertion
+            // mode without MSSTORE_CLIENT_ASSERTION set. Neither a client secret nor a certificate password is
+            // supplied, which used to reach ClearCredentials before anything had been validated.
+            ArrangeExistingClientSecretConfiguration(validationSucceeds: false);
+
+            await ReconfigureAsync(["--clientAssertion"], expectedResult: -1);
+
+            VerifyCredentialStoreWasNotTouched();
+        }
+
+        [TestMethod]
+        public async Task FailedCertificateThumbprintReconfigureShouldNotDestroyExistingClientSecret()
+        {
+            // --certificateThumbprint reached the same branch, so the bug was never client-assertion specific.
+            ArrangeExistingClientSecretConfiguration(validationSucceeds: false);
+
+            await ReconfigureAsync(["--certificateThumbprint", "abc"], expectedResult: -1);
+
+            VerifyCredentialStoreWasNotTouched();
+        }
+
+        [TestMethod]
+        public async Task FailedClientSecretReconfigureShouldNotOverwriteExistingClientSecret()
+        {
+            ArrangeExistingClientSecretConfiguration(validationSucceeds: false);
+
+            await ReconfigureAsync(["--clientSecret", "brandNewSecret"], expectedResult: -1);
+
+            VerifyCredentialStoreWasNotTouched();
+        }
+
+        [TestMethod]
+        public async Task FailedCertificateFileReconfigureShouldNotDestroyExistingClientSecret()
+        {
+            ArrangeExistingClientSecretConfiguration(validationSucceeds: false);
+
+            await ReconfigureAsync(["--certificateFilePath", "C:\\x.pfx", "--certificatePassword", "certPassword"], expectedResult: -1);
+
+            VerifyCredentialStoreWasNotTouched();
+        }
+
+        [TestMethod]
+        public async Task ReconfigureShouldValidateBeforeMutatingTheCredentialStore()
+        {
+            ArrangeExistingClientSecretConfiguration(validationSucceeds: true);
+
+            await ReconfigureAsync(["--clientSecret", "brandNewSecret"], expectedResult: 0);
+
+            // The store still held the old secret while the candidate configuration was being validated, proving
+            // validation no longer needs the new credential to be staged in the store first.
+            _credentialStoreDuringValidation.Should().ContainSingle();
+            _credentialStoreDuringValidation[0][ExistingClientId].Should().Be(ExistingSecret);
+
+            // And validation never consults the store at all - the candidate secret is passed in explicitly.
+            CredentialManager.Verify(x => x.ReadCredential(It.IsAny<string>()), Times.Never);
+
+            _credentialStore[ExistingClientId].Should().Be("brandNewSecret");
+        }
+
+        [TestMethod]
+        public async Task SuccessfulClientSecretReconfigureShouldStoreTheSecret()
+        {
+            ArrangeExistingClientSecretConfiguration(validationSucceeds: true);
+
+            await ReconfigureAsync(["--clientSecret", "brandNewSecret"], expectedResult: 0);
+
+            _validationSecrets.Should().ContainSingle().Which.Should().Be("brandNewSecret");
+            _credentialStore[ExistingClientId].Should().Be("brandNewSecret");
+
+            CredentialManager.Verify(x => x.ClearCredentials(It.IsAny<string>()), Times.Never);
+            FakeConfigurationManager.Verify(x => x.SaveAsync(It.IsAny<Configurations>(), It.IsAny<CancellationToken>()), Times.Once);
+        }
+
+        [TestMethod]
+        public async Task SuccessfulCertificatePasswordReconfigureShouldStoreThePassword()
+        {
+            ArrangeExistingClientSecretConfiguration(validationSucceeds: true);
+
+            await ReconfigureAsync(["--certificateFilePath", "C:\\x.pfx", "--certificatePassword", "certPassword"], expectedResult: 0);
+
+            // The certificate password doubles as the PKCS#12 password used to load the certificate file.
+            _validationSecrets.Should().ContainSingle().Which.Should().Be("certPassword");
+            _credentialStore[ExistingClientId].Should().Be("certPassword");
+
+            CredentialManager.Verify(x => x.ClearCredentials(It.IsAny<string>()), Times.Never);
+            FakeConfigurationManager.Verify(x => x.SaveAsync(It.IsAny<Configurations>(), It.IsAny<CancellationToken>()), Times.Once);
+        }
+
+        [TestMethod]
+        public async Task PasswordLessCertificateFileReconfigureShouldNotValidateWithTheStaleSecret()
+        {
+            ArrangeExistingClientSecretConfiguration(validationSucceeds: true);
+
+            await ReconfigureAsync(["--certificateFilePath", "C:\\x.pfx"], expectedResult: 0);
+
+            // A password-less certificate file must be loaded with a null PKCS#12 password. Simply deferring the
+            // credential clear would have left the previous client secret in the store, where it would have been
+            // silently used as the certificate password instead.
+            _validationSecrets.Should().ContainSingle().Which.Should().BeNull();
+
+            _credentialStore.Should().NotContainKey(ExistingClientId);
+            FakeConfigurationManager.Verify(x => x.SaveAsync(It.IsAny<Configurations>(), It.IsAny<CancellationToken>()), Times.Once);
+        }
+
+        [TestMethod]
+        public async Task SuccessfulClientAssertionReconfigureShouldClearTheObsoleteSecret()
+        {
+            ArrangeExistingClientSecretConfiguration(validationSucceeds: true);
+
+            await ReconfigureAsync(["--clientAssertion"], expectedResult: 0);
+
+            _validationSecrets.Should().ContainSingle().Which.Should().BeNull();
+
+            // Once the client-assertion configuration is validated and saved, the client secret is obsolete.
+            _credentialStore.Should().NotContainKey(ExistingClientId);
+            FakeConfigurationManager.Verify(x => x.SaveAsync(It.IsAny<Configurations>(), It.IsAny<CancellationToken>()), Times.Once);
+        }
+
+        [TestMethod]
+        public async Task SuccessfulCertificateThumbprintReconfigureShouldClearTheObsoleteSecret()
+        {
+            ArrangeExistingClientSecretConfiguration(validationSucceeds: true);
+
+            await ReconfigureAsync(["--certificateThumbprint", "abc"], expectedResult: 0);
+
+            _validationSecrets.Should().ContainSingle().Which.Should().BeNull();
+
+            _credentialStore.Should().NotContainKey(ExistingClientId);
+            FakeConfigurationManager.Verify(x => x.SaveAsync(It.IsAny<Configurations>(), It.IsAny<CancellationToken>()), Times.Once);
+        }
+    }
+}

--- a/MSStore.CLI.UnitTests/ReconfigureCredentialSafetyUnitTests.cs
+++ b/MSStore.CLI.UnitTests/ReconfigureCredentialSafetyUnitTests.cs
@@ -164,6 +164,41 @@ namespace MSStore.CLI.UnitTests
         }
 
         [TestMethod]
+        public async Task SilentlyFailedCredentialClearShouldNotReportSuccess()
+        {
+            // ClearCredentials cannot report failure on any platform, so a credential can survive the clear. The
+            // saved configuration would then be validated with a null PKCS#12 password but run with the stale
+            // secret as the password, so reconfigure must not claim success.
+            ArrangeExistingClientSecretConfiguration(validationSucceeds: true);
+            CredentialManager
+                .Setup(x => x.ClearCredentials(It.IsAny<string>()))
+                .Callback(() => { });
+
+            var result = await ReconfigureAsync(["--certificateFilePath", "C:\\x.pfx"], expectedResult: -1);
+
+            result.Error.Should().NotContain("Awesome! It seems to be working!");
+            result.Error.Should().Contain("could not be removed");
+
+            _credentialStore[ExistingClientId].Should().Be(ExistingSecret);
+            FakeConfigurationManager.Verify(x => x.SaveAsync(It.IsAny<Configurations>(), It.IsAny<CancellationToken>()), Times.Once);
+        }
+
+        [TestMethod]
+        public async Task SuccessfulCredentialClearShouldBeVerifiedAndReportSuccess()
+        {
+            ArrangeExistingClientSecretConfiguration(validationSucceeds: true);
+
+            var result = await ReconfigureAsync(["--certificateFilePath", "C:\\x.pfx"], expectedResult: 0);
+
+            // The clear is confirmed by reading the credential back, rather than assumed to have worked.
+            // Guid.ToString() is lower-case, so match the client ID case-insensitively.
+            CredentialManager.Verify(
+                x => x.ReadCredential(It.Is<string>(s => s.Equals(ExistingClientId, StringComparison.OrdinalIgnoreCase))),
+                Times.Once);
+            result.Error.Should().Contain("Awesome! It seems to be working!");
+        }
+
+        [TestMethod]
         public async Task ReconfigureShouldValidateBeforeMutatingTheCredentialStore()
         {
             ArrangeExistingClientSecretConfiguration(validationSucceeds: true);

--- a/MSStore.CLI.UnitTests/ReconfigureCredentialSafetyUnitTests.cs
+++ b/MSStore.CLI.UnitTests/ReconfigureCredentialSafetyUnitTests.cs
@@ -199,6 +199,47 @@ namespace MSStore.CLI.UnitTests
         }
 
         [TestMethod]
+        public async Task ResetShouldNotDiscardSettingsWhenTheCredentialSurvivesTheClear()
+        {
+            // `reconfigure --reset` used to report success whenever ClearCredentials silently failed. Wiping
+            // settings.json while an unremovable credential lingers leaves the machine worse off than before.
+            ArrangeExistingClientSecretConfiguration(validationSucceeds: true);
+            FakeConfigurationManager
+                .Setup(x => x.LoadAsync(It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new Configurations { ClientId = new Guid(ExistingClientId) });
+            CredentialManager
+                .Setup(x => x.ClearCredentials(It.IsAny<string>()))
+                .Callback(() => { });
+            FakeConsole
+                .Setup(x => x.YesNoConfirmationAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(true);
+
+            await ParseAndInvokeAsync(["reconfigure", "--reset"], expectedResult: -1);
+
+            _credentialStore[ExistingClientId].Should().Be(ExistingSecret);
+            FakeConfigurationManager.Verify(x => x.ClearAsync(It.IsAny<CancellationToken>()), Times.Never);
+            TokenManager.Verify(x => x.ClearAllCacheAsync(), Times.Never);
+        }
+
+        [TestMethod]
+        public async Task ResetShouldClearEverythingWhenTheCredentialIsRemoved()
+        {
+            ArrangeExistingClientSecretConfiguration(validationSucceeds: true);
+            FakeConfigurationManager
+                .Setup(x => x.LoadAsync(It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new Configurations { ClientId = new Guid(ExistingClientId) });
+            FakeConsole
+                .Setup(x => x.YesNoConfirmationAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(true);
+
+            await ParseAndInvokeAsync(["reconfigure", "--reset"], expectedResult: 0);
+
+            _credentialStore.Should().NotContainKey(ExistingClientId);
+            FakeConfigurationManager.Verify(x => x.ClearAsync(It.IsAny<CancellationToken>()), Times.Once);
+            TokenManager.Verify(x => x.ClearAllCacheAsync(), Times.Once);
+        }
+
+        [TestMethod]
         public async Task ReconfigureShouldValidateBeforeMutatingTheCredentialStore()
         {
             ArrangeExistingClientSecretConfiguration(validationSucceeds: true);

--- a/MSStore.CLI.UnitTests/ReconfigureCredentialSafetyUnitTests.cs
+++ b/MSStore.CLI.UnitTests/ReconfigureCredentialSafetyUnitTests.cs
@@ -78,14 +78,17 @@ namespace MSStore.CLI.UnitTests
                 expectedResult);
         }
 
-        private void VerifyCredentialStoreWasNotTouched()
+        private void VerifyCredentialStoreWasNotTouched(bool saveAttempted = false)
         {
             _credentialStore.Should().ContainKey(ExistingClientId);
             _credentialStore[ExistingClientId].Should().Be(ExistingSecret);
 
             CredentialManager.Verify(x => x.WriteCredential(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
             CredentialManager.Verify(x => x.ClearCredentials(It.IsAny<string>()), Times.Never);
-            FakeConfigurationManager.Verify(x => x.SaveAsync(It.IsAny<Configurations>(), It.IsAny<CancellationToken>()), Times.Never);
+
+            FakeConfigurationManager.Verify(
+                x => x.SaveAsync(It.IsAny<Configurations>(), It.IsAny<CancellationToken>()),
+                saveAttempted ? Times.Once() : Times.Never());
         }
 
         [TestMethod]
@@ -130,6 +133,34 @@ namespace MSStore.CLI.UnitTests
             await ReconfigureAsync(["--certificateFilePath", "C:\\x.pfx", "--certificatePassword", "certPassword"], expectedResult: -1);
 
             VerifyCredentialStoreWasNotTouched();
+        }
+
+        [TestMethod]
+        public async Task SaveFailureShouldNotOverwriteExistingClientSecret()
+        {
+            // Validation passes, but persisting settings.json fails. Writing the certificate password would
+            // overwrite - and permanently destroy - the client secret the saved configuration still refers to.
+            ArrangeExistingClientSecretConfiguration(validationSucceeds: true);
+            FakeConfigurationManager
+                .Setup(x => x.SaveAsync(It.IsAny<Configurations>(), It.IsAny<CancellationToken>()))
+                .ThrowsAsync(new IOException("settings.json is locked"));
+
+            await ReconfigureAsync(["--certificateFilePath", "C:\\x.pfx", "--certificatePassword", "certPassword"], expectedResult: -1);
+
+            VerifyCredentialStoreWasNotTouched(saveAttempted: true);
+        }
+
+        [TestMethod]
+        public async Task SaveFailureShouldNotClearExistingClientSecret()
+        {
+            ArrangeExistingClientSecretConfiguration(validationSucceeds: true);
+            FakeConfigurationManager
+                .Setup(x => x.SaveAsync(It.IsAny<Configurations>(), It.IsAny<CancellationToken>()))
+                .ThrowsAsync(new IOException("settings.json is locked"));
+
+            await ReconfigureAsync(["--clientAssertion"], expectedResult: -1);
+
+            VerifyCredentialStoreWasNotTouched(saveAttempted: true);
         }
 
         [TestMethod]

--- a/MSStore.CLI.UnitTests/StoreAPIFactoryUnitTests.cs
+++ b/MSStore.CLI.UnitTests/StoreAPIFactoryUnitTests.cs
@@ -1,0 +1,76 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.Extensions.Logging;
+using MSStore.API;
+using MSStore.CLI.Services;
+using MSStore.CLI.Services.CredentialManager;
+
+namespace MSStore.CLI.UnitTests
+{
+    [TestClass]
+    public class StoreAPIFactoryUnitTests
+    {
+        private static readonly Guid ClientId = new("3F0BCAEF-6334-48CF-837F-81CB0F1F2C45");
+
+        private Mock<IConfigurationManager<Configurations>> _configurationManager = null!;
+        private Mock<ICredentialManager> _credentialManager = null!;
+        private StoreAPIFactory _factory = null!;
+
+        public TestContext TestContext { get; set; } = null!;
+
+        [TestInitialize]
+        public void Initialize()
+        {
+            _configurationManager = new Mock<IConfigurationManager<Configurations>>();
+            _credentialManager = new Mock<ICredentialManager>();
+
+            _factory = new StoreAPIFactory(
+                _configurationManager.Object,
+                _credentialManager.Object,
+                new Mock<IHttpClientFactory>().Object,
+                new Mock<ILogger<StoreAPI>>().Object);
+        }
+
+        private static Configurations ConfigWithNoCertificate() => new()
+        {
+            SellerId = 1,
+            TenantId = new Guid("41261775-DB6D-4B44-9A36-7EB8565C7D22"),
+            ClientId = ClientId
+        };
+
+        [TestMethod]
+        public async Task CreateAsyncShouldReadTheSecretFromTheCredentialStore()
+        {
+            _credentialManager
+                .Setup(x => x.ReadCredential(ClientId.ToString()))
+                .Returns(string.Empty);
+
+            await Assert.ThrowsAsync<InvalidOperationException>(() => _factory.CreateAsync(ConfigWithNoCertificate(), TestContext.CancellationToken));
+
+            _credentialManager.Verify(x => x.ReadCredential(ClientId.ToString()), Times.Once);
+        }
+
+        [TestMethod]
+        public async Task CreateWithSecretAsyncShouldNeverReadTheCredentialStore()
+        {
+            // The whole point of this overload: a candidate configuration can be validated without the credential
+            // store having been staged with (or emptied of) anything first.
+            await Assert.ThrowsAsync<InvalidOperationException>(() => _factory.CreateWithSecretAsync(ConfigWithNoCertificate(), null, TestContext.CancellationToken));
+
+            _credentialManager.Verify(x => x.ReadCredential(It.IsAny<string>()), Times.Never);
+        }
+
+        [TestMethod]
+        public async Task CreateWithSecretAsyncShouldRequireAClientId()
+        {
+            await Assert.ThrowsAsync<InvalidOperationException>(() => _factory.CreateWithSecretAsync(new Configurations(), "secret", TestContext.CancellationToken));
+        }
+
+        [TestMethod]
+        public async Task CreateWithSecretAsyncShouldRequireAConfiguration()
+        {
+            await Assert.ThrowsAsync<ArgumentNullException>(() => _factory.CreateWithSecretAsync(null!, "secret", TestContext.CancellationToken));
+        }
+    }
+}

--- a/MSStore.CLI/Services/CLIConfigurator.cs
+++ b/MSStore.CLI/Services/CLIConfigurator.cs
@@ -291,7 +291,7 @@ namespace MSStore.CLI.Services
             // "this configuration has no secret" (certificate thumbprint or client assertion mode, or a
             // password-less certificate file), and must not fall back to whatever is currently in the credential
             // store. The credential store is only mutated once the configuration has been validated and saved, so
-            // a failed reconfigure can never destroy the credentials the user is currently relying on.
+            // a reconfigure that does not succeed can never destroy the credentials the user is relying on.
             var candidateSecret = clientSecret ?? certificatePassword;
 
             config.SellerId = await RetrieveSellerId(ansiConsole, sellerId, ct);
@@ -357,17 +357,18 @@ namespace MSStore.CLI.Services
                     }
 
                     // The configuration is known to be good at this point, so it is now safe to commit it.
-                    // Write the new secret first (a non-destructive operation), then persist the configuration,
-                    // and only then erase a credential that the new configuration no longer needs. Clearing is the
-                    // one irreversible step - a client secret cannot be read back from Entra - so it goes last.
+                    // Persist settings.json first: writing a credential overwrites whatever was stored for this
+                    // client ID, and clearing one erases it outright, so both are irreversible - a client secret
+                    // cannot be read back from Entra. Doing them only after the new configuration is durably saved
+                    // keeps the invariant that a reconfigure which does not succeed leaves the credential store
+                    // exactly as it found it.
+                    await _configurationManager.SaveAsync(config, ct);
+
                     if (candidateSecret != null)
                     {
                         _credentialManager.WriteCredential(clientIdString, candidateSecret);
                     }
-
-                    await _configurationManager.SaveAsync(config, ct);
-
-                    if (candidateSecret == null)
+                    else
                     {
                         _credentialManager.ClearCredentials(clientIdString);
                     }

--- a/MSStore.CLI/Services/CLIConfigurator.cs
+++ b/MSStore.CLI/Services/CLIConfigurator.cs
@@ -368,21 +368,10 @@ namespace MSStore.CLI.Services
                     {
                         _credentialManager.WriteCredential(clientIdString, candidateSecret);
                     }
-                    else
+                    else if (!TryClearCredentials(clientIdString))
                     {
-                        _credentialManager.ClearCredentials(clientIdString);
-
-                        // ClearCredentials is best-effort on every platform: Windows swallows exceptions, and the
-                        // Linux and macOS implementations discard the native delete status. A credential that
-                        // survives the clear would be picked up by ReadCredential on the next run and handed to
-                        // LoadCertificate as the PKCS#12 password of a password-less certificate file, breaking
-                        // the very configuration that was just reported as working. Confirm the removal instead of
-                        // assuming it, so the saved configuration always matches what was validated.
-                        if (!string.IsNullOrEmpty(_credentialManager.ReadCredential(clientIdString)))
-                        {
-                            ctx.ErrorStatus(ansiConsole, $"The configuration was saved, but the obsolete credential for '{clientIdString}' could not be removed from the credential store. Remove it manually, or run 'msstore reconfigure --reset', before using the CLI.");
-                            return false;
-                        }
+                        ctx.ErrorStatus(ansiConsole, $"The configuration was saved, but the obsolete credential for '{clientIdString}' could not be removed from the credential store. Remove it manually before using the CLI.");
+                        return false;
                     }
                 }
                 catch (Exception err)
@@ -402,6 +391,23 @@ namespace MSStore.CLI.Services
             }
 
             return result;
+        }
+
+        /// <summary>
+        /// Removes the credential stored for <paramref name="clientId"/> and confirms it is actually gone.
+        /// ClearCredentials is best-effort on every platform - Windows wraps the delete in a bare catch, and the
+        /// Linux and macOS implementations discard the native delete status - so a credential can survive the
+        /// clear silently. A leftover secret is then read back on the next run and handed to LoadCertificate as
+        /// the PKCS#12 password of a password-less certificate file, so the removal is verified rather than
+        /// assumed.
+        /// </summary>
+        /// <param name="clientId">The client Id whose credential should be removed.</param>
+        /// <returns><see langword="true"/> if no credential remains for the client Id.</returns>
+        private bool TryClearCredentials(string clientId)
+        {
+            _credentialManager.ClearCredentials(clientId);
+
+            return string.IsNullOrEmpty(_credentialManager.ReadCredential(clientId));
         }
 
         private async Task OpenPartnerCenterUserManagementPageAsync(string specificPage, CancellationToken ct)
@@ -672,9 +678,13 @@ namespace MSStore.CLI.Services
             {
                 var config = await _configurationManager.LoadAsync(true, ct: ct);
 
-                if (config.ClientId.HasValue)
+                // Remove the credential before discarding the settings, and only continue if it is really gone.
+                // Wiping settings.json while an unremovable credential lingers would leave the machine in a worse
+                // state than it started in, and reporting success would be a lie.
+                if (config.ClientId.HasValue && !TryClearCredentials(config.ClientId.Value.ToString()))
                 {
-                    _credentialManager.ClearCredentials(config.ClientId.Value.ToString());
+                    _logger.LogError("Could not remove the credential for '{ClientId}' from the credential store. Remove it manually.", config.ClientId.Value);
+                    return false;
                 }
 
                 await _configurationManager.ClearAsync(ct);

--- a/MSStore.CLI/Services/CLIConfigurator.cs
+++ b/MSStore.CLI/Services/CLIConfigurator.cs
@@ -38,6 +38,12 @@ namespace MSStore.CLI.Services
         private readonly ITokenManager _tokenManager = tokenManager ?? throw new ArgumentNullException(nameof(tokenManager));
         private readonly ILogger _logger = logger ?? throw new ArgumentNullException(nameof(logger));
 
+        /// <summary>
+        /// Gets or sets how long to wait between attempts when validating a candidate configuration. Overridable so
+        /// tests don't have to sit through the real back-off.
+        /// </summary>
+        internal static TimeSpan ValidationRetryDelay { get; set; } = TimeSpan.FromSeconds(10);
+
         public async Task<bool> ConfigureAsync(IAnsiConsole ansiConsole, bool askConfirmation, Guid? tenantId = null, string? sellerId = null, Guid? clientId = null, string? clientSecret = null, string? certificateThumbprint = null, string? certificateFilePath = null, string? certificatePassword = null, bool clientAssertion = false, CancellationToken ct = default)
         {
             if (askConfirmation &&
@@ -279,18 +285,14 @@ namespace MSStore.CLI.Services
                 return false;
             }
 
-            if (clientSecret != null)
-            {
-                _credentialManager.WriteCredential(config.ClientId.Value.ToString(), clientSecret);
-            }
-            else if (certificatePassword != null)
-            {
-                _credentialManager.WriteCredential(config.ClientId.Value.ToString(), certificatePassword);
-            }
-            else
-            {
-                _credentialManager.ClearCredentials(config.ClientId.Value.ToString());
-            }
+            var clientIdString = config.ClientId.Value.ToString();
+
+            // The secret that this candidate configuration should be validated with. A null value explicitly means
+            // "this configuration has no secret" (certificate thumbprint or client assertion mode, or a
+            // password-less certificate file), and must not fall back to whatever is currently in the credential
+            // store. The credential store is only mutated once the configuration has been validated and saved, so
+            // a failed reconfigure can never destroy the credentials the user is currently relying on.
+            var candidateSecret = clientSecret ?? certificatePassword;
 
             config.SellerId = await RetrieveSellerId(ansiConsole, sellerId, ct);
             if (config.SellerId == null)
@@ -319,12 +321,12 @@ namespace MSStore.CLI.Services
                 {
                     IStoreAPI? storeAPI = null;
                     int maxRetry = 3;
-                    int delay = 10;
+                    var delay = ValidationRetryDelay;
                     for (int i = 0; i < maxRetry; i++)
                     {
                         try
                         {
-                            storeAPI = await _storeAPIFactory.CreateAsync(config, ct);
+                            storeAPI = await _storeAPIFactory.CreateWithSecretAsync(config, candidateSecret, ct);
                             break;
                         }
                         catch (Exception ex)
@@ -342,8 +344,8 @@ namespace MSStore.CLI.Services
                                 break;
                             }
 
-                            ansiConsole.MarkupLine($"Failed to auth... Might just need to wait a little bit. Retrying again in [b green]{delay}[/] seconds([b green]{i + 1}/{maxRetry}[/])...");
-                            await Task.Delay(TimeSpan.FromSeconds(delay), ct);
+                            ansiConsole.MarkupLine($"Failed to auth... Might just need to wait a little bit. Retrying again in [b green]{delay.TotalSeconds}[/] seconds([b green]{i + 1}/{maxRetry}[/])...");
+                            await Task.Delay(delay, ct);
                         }
                     }
 
@@ -354,7 +356,21 @@ namespace MSStore.CLI.Services
                         return false;
                     }
 
+                    // The configuration is known to be good at this point, so it is now safe to commit it.
+                    // Write the new secret first (a non-destructive operation), then persist the configuration,
+                    // and only then erase a credential that the new configuration no longer needs. Clearing is the
+                    // one irreversible step - a client secret cannot be read back from Entra - so it goes last.
+                    if (candidateSecret != null)
+                    {
+                        _credentialManager.WriteCredential(clientIdString, candidateSecret);
+                    }
+
                     await _configurationManager.SaveAsync(config, ct);
+
+                    if (candidateSecret == null)
+                    {
+                        _credentialManager.ClearCredentials(clientIdString);
+                    }
                 }
                 catch (Exception err)
                 {

--- a/MSStore.CLI/Services/CLIConfigurator.cs
+++ b/MSStore.CLI/Services/CLIConfigurator.cs
@@ -371,6 +371,18 @@ namespace MSStore.CLI.Services
                     else
                     {
                         _credentialManager.ClearCredentials(clientIdString);
+
+                        // ClearCredentials is best-effort on every platform: Windows swallows exceptions, and the
+                        // Linux and macOS implementations discard the native delete status. A credential that
+                        // survives the clear would be picked up by ReadCredential on the next run and handed to
+                        // LoadCertificate as the PKCS#12 password of a password-less certificate file, breaking
+                        // the very configuration that was just reported as working. Confirm the removal instead of
+                        // assuming it, so the saved configuration always matches what was validated.
+                        if (!string.IsNullOrEmpty(_credentialManager.ReadCredential(clientIdString)))
+                        {
+                            ctx.ErrorStatus(ansiConsole, $"The configuration was saved, but the obsolete credential for '{clientIdString}' could not be removed from the credential store. Remove it manually, or run 'msstore reconfigure --reset', before using the CLI.");
+                            return false;
+                        }
                     }
                 }
                 catch (Exception err)

--- a/MSStore.CLI/Services/IStoreAPIFactory.cs
+++ b/MSStore.CLI/Services/IStoreAPIFactory.cs
@@ -11,6 +11,22 @@ namespace MSStore.CLI.Services
     internal interface IStoreAPIFactory
     {
         Task<IStoreAPI> CreateAsync(Configurations? config = null, CancellationToken ct = default);
+
+        /// <summary>
+        /// Creates an <see cref="IStoreAPI"/> for a candidate configuration, using the supplied secret instead of
+        /// reading one from the credential store. This allows a configuration to be validated without first having
+        /// to stage (or erase) credentials in the OS credential store.
+        /// </summary>
+        /// <param name="config">The candidate configuration.</param>
+        /// <param name="secret">
+        /// The client secret, or the certificate file password. A <see langword="null"/> value explicitly means
+        /// "this configuration has no secret" (certificate thumbprint, client assertion, or password-less
+        /// certificate file), and never falls back to the credential store.
+        /// </param>
+        /// <param name="ct">The cancellation token.</param>
+        /// <returns>The <see cref="IStoreAPI"/> instance.</returns>
+        Task<IStoreAPI> CreateWithSecretAsync(Configurations config, string? secret, CancellationToken ct = default);
+
         Task<IStorePackagedAPI> CreatePackagedAsync(Configurations? config = null, CancellationToken ct = default);
     }
 }

--- a/MSStore.CLI/Services/StoreAPIFactory.cs
+++ b/MSStore.CLI/Services/StoreAPIFactory.cs
@@ -29,7 +29,18 @@ namespace MSStore.CLI.Services
                 throw new InvalidOperationException("Configuration Client Id is empty.");
             }
 
-            var secret = _credentialManager.ReadCredential(config.ClientId.Value.ToString());
+            return await CreateWithSecretAsync(config, _credentialManager.ReadCredential(config.ClientId.Value.ToString()), ct);
+        }
+
+        public async Task<IStoreAPI> CreateWithSecretAsync(Configurations config, string? secret, CancellationToken ct = default)
+        {
+            ArgumentNullException.ThrowIfNull(config);
+
+            if (!config.ClientId.HasValue)
+            {
+                throw new InvalidOperationException("Configuration Client Id is empty.");
+            }
+
             X509Certificate2? cert = LoadCertificate(config, secret);
 
             StoreAPI? storeAPI;


### PR DESCRIPTION
Fixes #166

## The problem

`CLIConfigurator.ConfigureAsync` mutated the OS credential store *before* it validated the new configuration, and only wrote `settings.json` on success:

| Order | Step |
| --- | --- |
| 1 | Write **or clear** the stored credential |
| 2 | `_storeAPIFactory.CreateAsync(config, ct)` — the first real validation |
| 3 | `_configurationManager.SaveAsync(config, ct)` — written **only on success** |

The `else` branch in step 1 called `ClearCredentials` whenever neither `clientSecret` nor `certificatePassword` was supplied. So starting from a working client-secret configuration:

```
msstore reconfigure --clientAssertion    # same clientId, MSSTORE_CLIENT_ASSERTION not set
```

deleted the working secret, then failed validation, then never saved — leaving `settings.json` still in client-secret mode with the secret gone. Entra only reveals a client secret at creation time, so recovery meant minting a new one. `--certificateThumbprint` reached the same branch, so this was never client-assertion specific.

## Why reordering alone doesn't work

Two constraints ruled out simply moving the block:

1. `WriteCredential` had to stay ahead of validation, because `StoreAPIFactory` called `ReadCredential(clientId)` to construct the client it validates with.
2. Deferring only the `ClearCredentials` branch leaves the previous secret in the store during validation. On the certificate-file path that value is passed straight through as the PKCS#12 password in `StoreAPIFactory.LoadCertificate`, so a password-less `.pfx` would silently be opened with the stale client secret — changing behaviour for a mode unrelated to the trigger.

Snapshot-and-restore was also rejected: it's a best-effort undo, and the window it has to cover is the retry loop, which sleeps 10s between attempts and prints "Retrying..." — exactly when a user is most likely to hit Ctrl+C.

## The fix

Make the secret an **explicit input to validation** instead of something the factory goes and fetches.

`IStoreAPIFactory` gains `CreateWithSecretAsync(config, secret, ct)`, where a `null` secret unambiguously means *"this configuration has no secret"* and never falls back to the credential store. `CreateAsync` now delegates to it after reading the stored credential, so all other call sites are untouched.

`ConfigureAsync` then:

1. computes the candidate secret (`clientSecret ?? certificatePassword`) without touching the store,
2. validates the candidate configuration with it,
3. and only once that succeeds: saves `settings.json`, then writes the new credential or removes the obsolete one.

Persistence goes first because **both** credential operations are irreversible — `WriteCredential` overwrites whatever was stored for that client ID, and a client secret cannot be read back from Entra. A saved configuration whose credential is missing is recoverable (the user still has the secret they just supplied); an overwritten secret is not. That yields one invariant: **a reconfigure that does not succeed leaves the credential store exactly as it found it.**

### How this covers all three modes

| Mode | Candidate secret | Validated with | On success |
| --- | --- | --- | --- |
| Client secret | the secret | the secret | write it |
| Certificate — file + password | the password | the password (PKCS#12) | write it |
| Certificate — file, no password | `null` | `null` — **not** the stale secret | clear obsolete |
| Certificate — thumbprint | `null` | `null` | clear obsolete |
| Client assertion | `null` | `null` (assertion comes from env) | clear obsolete |

### Verified credential removal

`ClearCredentials` cannot report failure on any platform — Windows wraps the delete in a bare `catch { }`, and the Linux and macOS implementations discard the native delete status. A credential surviving the clear is therefore silent, and for a password-less certificate file it's harmful: validation runs with a `null` PKCS#12 password, but every later command reads the leftover secret and hands it to `LoadCertificate` as the password. Reconfigure would report success for a configuration that doesn't work.

Rather than change the `ICredentialManager` contract and the error handling of three native code paths, `TryClearCredentials` reads the credential back after clearing and reports failure with an actionable message if anything remains. The write branch needs no read-back — `WriteCredential` already throws on failure on all three platforms.

`reconfigure --reset` had the same defect: it cleared without verifying, then wiped `settings.json` and reported success regardless. It now clears first and bails before discarding the settings if anything remains, since wiping the configuration while an unremovable credential lingers leaves the machine worse off than it started.

## Tests

20 new tests across two files.

`ReconfigureCredentialSafetyUnitTests` swaps in a dictionary-backed in-memory credential store seeded with a working secret, so assertions look at real store state rather than a call log:

- **The regression tests**: a failed reconfigure via `--clientAssertion`, `--certificateThumbprint`, `--clientSecret`, and `--certificateFilePath` each leave the existing secret intact, with `WriteCredential`, `ClearCredentials`, and `SaveAsync` all never called.
- **Persistence-failure tests**: `SaveAsync` throwing on the write branch and on the clear branch both leave the store untouched.
- **Clear-verification tests**: a silently failed `ClearCredentials` must not report success; a successful one is confirmed by read-back rather than assumed.
- **Reset tests** (this path had no coverage at all before): a surviving credential blocks the settings wipe; the normal case clears everything.
- `ReconfigureShouldValidateBeforeMutatingTheCredentialStore` snapshots the store *during* validation and asserts it still held the old secret, and that `ReadCredential` is never called.
- `PasswordLessCertificateFileReconfigureShouldNotValidateWithTheStaleSecret` pins constraint 2 above.
- Success-path tests for each of the five rows in the table.

`StoreAPIFactoryUnitTests` covers the factory split directly (previously untested): `CreateAsync` reads the store, `CreateWithSecretAsync` never does.

**Each fix was verified to actually catch its bug** by temporarily restoring the old behaviour and confirming the relevant tests fail.

```
dotnet build MSStore.CLI.UnitTests\MSStore.CLI.UnitTests.csproj -v quiet --nologo
.\MSStore.CLI.UnitTests\bin\Debug\net10.0\MSStore.CLI.UnitTests.exe
```

- Baseline on `main`: 170 total, 160 succeeded, 10 skipped, 0 failed
- With this PR: **190 total, 180 succeeded, 10 skipped, 0 failed**
- `net10.0-windows10.0.17763.0`: 190 total, 182 succeeded, 8 skipped, 0 failed
- Full solution builds with **0 warnings**

## Two incidental changes

`CLIConfigurator.ValidationRetryDelay` makes the retry back-off overridable, mirroring the existing `StorePackagedAPI.DefaultSubmissionPollDelay` seam, so failure-path tests don't sit through 3 attempts × 10s of real sleeps. It also fixes the retry message, which now prints the delay actually in use.

The shared `ReadCredential` test double in `BaseCommandLineTest` threw on `UserNames.Last()` once `ClearCredentials` emptied the lists. Every real implementation returns an empty string for a missing credential, so the fake now matches that contract.
