### PR TITLE
Implement paging for listing apps and flights

### DIFF
--- a/MSStore.API/Packaged/Models/PagedResponse.cs
+++ b/MSStore.API/Packaged/Models/PagedResponse.cs
@@ -2,11 +2,13 @@
 // Licensed under the MIT License.
 
 using System.Collections.Generic;
+using System.Text.Json.Serialization;
 
 namespace MSStore.API.Packaged.Models
 {
     public class PagedResponse<T>
     {
+        [JsonPropertyName("@nextLink")]
         public string? NextLink { get; set; }
         public List<T>? Value { get; set; }
         public int TotalCount { get; set; }

--- a/MSStore.API/Packaged/StorePackagedAPI.cs
+++ b/MSStore.API/Packaged/StorePackagedAPI.cs
@@ -667,7 +667,7 @@ namespace MSStore.API.Packaged
         private static async IAsyncEnumerable<T> GetAllObjectsPagedAsync<T>(Func<int, int, CancellationToken, Task<PagedResponse<T>>> pageFunc, [EnumeratorCancellation] CancellationToken ct = default)
         {
             int skip = 0;
-            const int top = 10;
+            const int top = 100;
             PagedResponse<T>? lastPage;
             do
             {

--- a/MSStore.API/Packaged/StorePackagedAPI.cs
+++ b/MSStore.API/Packaged/StorePackagedAPI.cs
@@ -219,8 +219,18 @@ namespace MSStore.API.Packaged
         {
             try
             {
-                var devCenterApplicationsResponse = await GetDevCenterApplicationsAsync(0, 100, ct); // TODO: pagination
-                return devCenterApplicationsResponse.Value ?? [];
+                PagedResponse<DevCenterApplication>? lastDevCenterApplicationsResponse = null;
+                var result = new List<DevCenterApplication>();
+                int skip = 0;
+                const int top = 100;
+                do
+                {
+                    lastDevCenterApplicationsResponse = await GetDevCenterApplicationsAsync(skip, top, ct);
+                    skip += top;
+                    result.AddRange(lastDevCenterApplicationsResponse.Value ?? []);
+                }
+                while (lastDevCenterApplicationsResponse?.NextLink is not null);
+                return result;
             }
             catch (Exception error)
             {
@@ -384,8 +394,18 @@ namespace MSStore.API.Packaged
         {
             try
             {
-                var devCenterFlightsResponse = await GetFlightsAsync(productId, 0, 100, ct); // TODO: pagination
-                return devCenterFlightsResponse.Value ?? [];
+                PagedResponse<DevCenterFlight>? lastDevCenterFlightsResponse = null;
+                var result = new List<DevCenterFlight>();
+                int skip = 0;
+                const int top = 100;
+                do
+                {
+                    lastDevCenterFlightsResponse = await GetFlightsAsync(productId, skip, top, ct);
+                    skip += top;
+                    result.AddRange(lastDevCenterFlightsResponse.Value ?? []);
+                }
+                while (lastDevCenterFlightsResponse?.NextLink is not null);
+                return result;
             }
             catch (Exception error)
             {

--- a/MSStore.API/Packaged/StorePackagedAPI.cs
+++ b/MSStore.API/Packaged/StorePackagedAPI.cs
@@ -5,7 +5,9 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
+using System.Linq;
 using System.Net.Http;
+using System.Runtime.CompilerServices;
 using System.Security.Cryptography.X509Certificates;
 using System.Text;
 using System.Text.Json;
@@ -219,18 +221,7 @@ namespace MSStore.API.Packaged
         {
             try
             {
-                PagedResponse<DevCenterApplication>? lastDevCenterApplicationsResponse = null;
-                var result = new List<DevCenterApplication>();
-                int skip = 0;
-                const int top = 100;
-                do
-                {
-                    lastDevCenterApplicationsResponse = await GetDevCenterApplicationsAsync(skip, top, ct);
-                    skip += top;
-                    result.AddRange(lastDevCenterApplicationsResponse.Value ?? []);
-                }
-                while (lastDevCenterApplicationsResponse?.NextLink is not null);
-                return result;
+                return await GetAllObjectsPagedAsync<DevCenterApplication>(pageFunc: GetDevCenterApplicationsAsync, ct).ToListAsync(ct);
             }
             catch (Exception error)
             {
@@ -394,18 +385,7 @@ namespace MSStore.API.Packaged
         {
             try
             {
-                PagedResponse<DevCenterFlight>? lastDevCenterFlightsResponse = null;
-                var result = new List<DevCenterFlight>();
-                int skip = 0;
-                const int top = 100;
-                do
-                {
-                    lastDevCenterFlightsResponse = await GetFlightsAsync(productId, skip, top, ct);
-                    skip += top;
-                    result.AddRange(lastDevCenterFlightsResponse.Value ?? []);
-                }
-                while (lastDevCenterFlightsResponse?.NextLink is not null);
-                return result;
+                return await GetAllObjectsPagedAsync<DevCenterFlight>((skip, top, ct) => GetFlightsAsync(productId, skip, top, ct), ct).ToListAsync(ct);
             }
             catch (Exception error)
             {
@@ -682,6 +662,26 @@ namespace MSStore.API.Packaged
                 null,
                 SourceGenerationContext.GetCustom().PackageRollout,
                 ct);
+        }
+
+        private static async IAsyncEnumerable<T> GetAllObjectsPagedAsync<T>(Func<int, int, CancellationToken, Task<PagedResponse<T>>> pageFunc, [EnumeratorCancellation] CancellationToken ct = default)
+        {
+            int skip = 0;
+            int top = 100;
+            PagedResponse<T>? lastPage;
+            do
+            {
+                ct.ThrowIfCancellationRequested();
+
+                lastPage = await pageFunc(skip, top, ct);
+                skip += top;
+
+                foreach (var item in lastPage.Value ?? [])
+                {
+                    yield return item;
+                }
+            }
+            while (!string.IsNullOrEmpty(lastPage.NextLink) && lastPage.Value?.Count == top);
         }
     }
 }

--- a/MSStore.API/Packaged/StorePackagedAPI.cs
+++ b/MSStore.API/Packaged/StorePackagedAPI.cs
@@ -667,7 +667,7 @@ namespace MSStore.API.Packaged
         private static async IAsyncEnumerable<T> GetAllObjectsPagedAsync<T>(Func<int, int, CancellationToken, Task<PagedResponse<T>>> pageFunc, [EnumeratorCancellation] CancellationToken ct = default)
         {
             int skip = 0;
-            int top = 100;
+            const int top = 10;
             PagedResponse<T>? lastPage;
             do
             {
@@ -681,7 +681,7 @@ namespace MSStore.API.Packaged
                     yield return item;
                 }
             }
-            while (!string.IsNullOrEmpty(lastPage.NextLink) && lastPage.Value?.Count == top);
+            while (lastPage is { NextLink.Length: > 0, Value.Count: top });
         }
     }
 }

--- a/MSStore.API/Packaged/StorePackagedAPI.cs
+++ b/MSStore.API/Packaged/StorePackagedAPI.cs
@@ -683,7 +683,7 @@ namespace MSStore.API.Packaged
                     yield return item;
                 }
             }
-            while (!string.IsNullOrEmpty(lastPage.NextLink) && lastPage.Value?.Count > 0 && skip < lastPage.TotalCount);
+            while (!string.IsNullOrEmpty(lastPage.NextLink) && lastPage.Value?.Count > 0 && (lastPage.TotalCount <= 0 || skip < lastPage.TotalCount));
         }
     }
 }

--- a/MSStore.API/Packaged/StorePackagedAPI.cs
+++ b/MSStore.API/Packaged/StorePackagedAPI.cs
@@ -221,7 +221,7 @@ namespace MSStore.API.Packaged
         {
             try
             {
-                return await GetAllObjectsPagedAsync<DevCenterApplication>(pageFunc: GetDevCenterApplicationsAsync, ct).ToListAsync(ct);
+                return await GetAllPagesAsync<DevCenterApplication>(pageFunc: GetDevCenterApplicationsAsync, ct).ToListAsync(ct);
             }
             catch (Exception error)
             {
@@ -385,7 +385,7 @@ namespace MSStore.API.Packaged
         {
             try
             {
-                return await GetAllObjectsPagedAsync<DevCenterFlight>((skip, top, ct) => GetFlightsAsync(productId, skip, top, ct), ct).ToListAsync(ct);
+                return await GetAllPagesAsync<DevCenterFlight>((skip, top, ct) => GetFlightsAsync(productId, skip, top, ct), ct).ToListAsync(ct);
             }
             catch (Exception error)
             {
@@ -664,7 +664,7 @@ namespace MSStore.API.Packaged
                 ct);
         }
 
-        private static async IAsyncEnumerable<T> GetAllObjectsPagedAsync<T>(Func<int, int, CancellationToken, Task<PagedResponse<T>>> pageFunc, [EnumeratorCancellation] CancellationToken ct = default)
+        private static async IAsyncEnumerable<T> GetAllPagesAsync<T>(Func<int, int, CancellationToken, Task<PagedResponse<T>>> pageFunc, [EnumeratorCancellation] CancellationToken ct = default)
         {
             int skip = 0;
             const int top = 100;

--- a/MSStore.API/Packaged/StorePackagedAPI.cs
+++ b/MSStore.API/Packaged/StorePackagedAPI.cs
@@ -221,7 +221,7 @@ namespace MSStore.API.Packaged
         {
             try
             {
-                return await GetAllPagesAsync<DevCenterApplication>(pageFunc: GetDevCenterApplicationsAsync, ct).ToListAsync(ct);
+                return await GetAllPagesAsync<DevCenterApplication>(GetDevCenterApplicationsAsync, ct).ToListAsync(ct);
             }
             catch (Exception error)
             {

--- a/MSStore.API/Packaged/StorePackagedAPI.cs
+++ b/MSStore.API/Packaged/StorePackagedAPI.cs
@@ -385,7 +385,7 @@ namespace MSStore.API.Packaged
         {
             try
             {
-                return await GetAllPagesAsync<DevCenterFlight>((skip, top, ct) => GetFlightsAsync(productId, skip, top, ct), ct).ToListAsync(ct);
+                return await GetAllPagesAsync<DevCenterFlight>((skip, top, token) => GetFlightsAsync(productId, skip, top, token), ct).ToListAsync(ct);
             }
             catch (Exception error)
             {
@@ -667,21 +667,23 @@ namespace MSStore.API.Packaged
         private static async IAsyncEnumerable<T> GetAllPagesAsync<T>(Func<int, int, CancellationToken, Task<PagedResponse<T>>> pageFunc, [EnumeratorCancellation] CancellationToken ct = default)
         {
             int skip = 0;
-            const int top = 100;
+            const int top = 10;
             PagedResponse<T>? lastPage;
             do
             {
                 ct.ThrowIfCancellationRequested();
 
                 lastPage = await pageFunc(skip, top, ct);
-                skip += top;
+                skip += lastPage.Value?.Count ?? 0;
 
                 foreach (var item in lastPage.Value ?? [])
                 {
+                    ct.ThrowIfCancellationRequested();
+
                     yield return item;
                 }
             }
-            while (lastPage is { NextLink.Length: > 0, Value.Count: top });
+            while (!string.IsNullOrEmpty(lastPage.NextLink) && skip < lastPage.TotalCount);
         }
     }
 }

--- a/MSStore.API/Packaged/StorePackagedAPI.cs
+++ b/MSStore.API/Packaged/StorePackagedAPI.cs
@@ -667,7 +667,7 @@ namespace MSStore.API.Packaged
         private static async IAsyncEnumerable<T> GetAllPagesAsync<T>(Func<int, int, CancellationToken, Task<PagedResponse<T>>> pageFunc, [EnumeratorCancellation] CancellationToken ct = default)
         {
             int skip = 0;
-            const int top = 10;
+            const int top = 100;
             PagedResponse<T>? lastPage;
             do
             {

--- a/MSStore.API/Packaged/StorePackagedAPI.cs
+++ b/MSStore.API/Packaged/StorePackagedAPI.cs
@@ -683,7 +683,7 @@ namespace MSStore.API.Packaged
                     yield return item;
                 }
             }
-            while (!string.IsNullOrEmpty(lastPage.NextLink) && skip < lastPage.TotalCount);
+            while (!string.IsNullOrEmpty(lastPage.NextLink) && lastPage.Value?.Count > 0 && skip < lastPage.TotalCount);
         }
     }
 }


### PR DESCRIPTION
fixes #170 and removes some todo's from code

## current problem
paging is not implement and people report hitting the existing default of 100 apps.

## Implementation
Using the next link to decide if new page need to be retrieved but not using it as a template as it doesn't fit very well in the existing way of templating urls (nextlink for application is `applications?top=100&skip=100` while the existing templates assume application is coming from code; 
