### PR TITLE
Let human-readable output be routed to stdout

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,9 +44,13 @@ jobs:
     - name: Build
       run: dotnet build MSStore.CLI.sln --no-restore /p:Configuration=Release
     - name: Test net10.0
+      env:
+        MSSTORE_RUN_PROCESS_TESTS: 'true'
       run: dotnet run --project MSStore.CLI.UnitTests -f net10.0 --no-build -c Release --coverage --coverage-output-format cobertura --report-trx --results-directory ./TestResults
     - name: Test net10.0-windows10.0.17763.0
       if: ${{ matrix.os == 'windows-latest' }}
+      env:
+        MSSTORE_RUN_PROCESS_TESTS: 'true'
       run: dotnet run --project MSStore.CLI.UnitTests -f net10.0-windows10.0.17763.0 --no-build -c Release --coverage --coverage-output-format cobertura --report-trx --results-directory ./TestResults
     - name: Publish test results
       if: ${{ !cancelled() }}

--- a/.pipelines/templates/build-and-tests.yaml
+++ b/.pipelines/templates/build-and-tests.yaml
@@ -39,6 +39,7 @@ steps:
   displayName: 'Tests net10.0'
   env:
     DISPLAY: :0.0
+    MSSTORE_RUN_PROCESS_TESTS: 'true'
   inputs:
     command: 'run'
     projects: '**/*[Tt]est*/*.csproj'
@@ -48,6 +49,7 @@ steps:
   condition: startsWith(variables.AgentOS, 'Windows_NT')
   env:
     DISPLAY: :0.0
+    MSSTORE_RUN_PROCESS_TESTS: 'true'
   inputs:
     command: 'run'
     projects: '**/*[Tt]est*/*.csproj'

--- a/MSStore.CLI.UnitTests/AppsCommandUnitTests.cs
+++ b/MSStore.CLI.UnitTests/AppsCommandUnitTests.cs
@@ -23,8 +23,8 @@ namespace MSStore.CLI.UnitTests
                     "list"
                 ]);
 
-            result.Output.Should().ContainAll(FakeApps.Select(a => a.Id));
-            result.Output.Should().ContainAll(FakeApps.Select(a => a.PrimaryName));
+            result.Error.Should().ContainAll(FakeApps.Select(a => a.Id));
+            result.Error.Should().ContainAll(FakeApps.Select(a => a.PrimaryName));
         }
 
         [TestMethod]

--- a/MSStore.CLI.UnitTests/BaseCommandLineTest.cs
+++ b/MSStore.CLI.UnitTests/BaseCommandLineTest.cs
@@ -802,8 +802,9 @@ namespace MSStore.CLI.UnitTests
             var outputCapture = new OutputCapture(Console.Out);
             var errorCapture = RefreshAnsiConsole();
 
-            // Only stdout is redirected: the error capture is reached exclusively through
-            // ErrorAnsiConsole, mirroring how Program.cs keeps the two streams apart.
+            // Only stdout is redirected: it is reserved for StandardOutput payloads. Human-readable writes
+            // reach the error capture through either ErrorAnsiConsole or the static console, mirroring how
+            // Program.cs points both at the same instance.
             Console.SetOut(outputCapture);
 
             AnsiConsole.Console = AnsiConsole.Create(new AnsiConsoleSettings
@@ -811,7 +812,7 @@ namespace MSStore.CLI.UnitTests
                 Ansi = AnsiSupport.Yes,
                 ColorSystem = ColorSystemSupport.TrueColor,
                 Interactive = InteractionSupport.No,
-                Out = new CustomAnsiConsoleOutput(outputCapture),
+                Out = new CustomAnsiConsoleOutput(errorCapture),
                 Enrichment = new ProfileEnrichment
                 {
                     UseDefaultEnrichers = false

--- a/MSStore.CLI.UnitTests/ConsoleFactoryUnitTests.cs
+++ b/MSStore.CLI.UnitTests/ConsoleFactoryUnitTests.cs
@@ -1,0 +1,103 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using MSStore.CLI.Helpers;
+using Spectre.Console;
+
+namespace MSStore.CLI.UnitTests
+{
+    /// <summary>
+    /// Covers the console that <see cref="Program"/> builds, including the static
+    /// <see cref="AnsiConsole.Console"/> assignment that the tables, prompts and browser launcher depend on.
+    /// </summary>
+    [TestClass]
+    public class ConsoleFactoryUnitTests
+    {
+        private const string Marker = "console-factory-marker";
+
+        private IAnsiConsole _previousConsole = null!;
+        private TextWriter _previousOut = null!;
+        private TextWriter _previousError = null!;
+        private StringWriter _stdOut = null!;
+        private StringWriter _stdError = null!;
+
+        [TestInitialize]
+        public void Initialize()
+        {
+            _previousConsole = AnsiConsole.Console;
+            _previousOut = Console.Out;
+            _previousError = Console.Error;
+
+            // ConsoleFactory captures Console.Out/Console.Error when it builds the AnsiConsoleOutput, so the
+            // redirection has to be in place first.
+            _stdOut = new StringWriter();
+            _stdError = new StringWriter();
+            Console.SetOut(_stdOut);
+            Console.SetError(_stdError);
+        }
+
+        [TestCleanup]
+        public void Cleanup()
+        {
+            Console.SetOut(_previousOut);
+            Console.SetError(_previousError);
+            AnsiConsole.Console = _previousConsole;
+            _stdOut.Dispose();
+            _stdError.Dispose();
+        }
+
+        [TestMethod]
+        public void CreateWritesToStandardErrorForStderr()
+        {
+            var console = ConsoleFactory.Create(OutputStream.Stderr);
+
+            console.WriteLine(Marker);
+
+            _stdError.ToString().Should().Contain(Marker);
+            _stdOut.ToString().Should().NotContain(Marker);
+        }
+
+        [TestMethod]
+        public void CreateWritesToStandardOutputForStdout()
+        {
+            var console = ConsoleFactory.Create(OutputStream.Stdout);
+
+            console.WriteLine(Marker);
+
+            _stdOut.ToString().Should().Contain(Marker);
+            _stdError.ToString().Should().NotContain(Marker);
+        }
+
+        [TestMethod]
+        public void CreateInstallsTheConsoleAsTheStaticConsole()
+        {
+            var console = ConsoleFactory.Create(OutputStream.Stderr);
+
+            AnsiConsole.Console.Should().BeSameAs(console);
+        }
+
+        [TestMethod]
+        public void StaticWritesFollowStderr()
+        {
+            // The apps/flights/info tables, the browser launcher and every ConsoleReader prompt write through
+            // the static console, so it has to honour the selected stream too.
+            ConsoleFactory.Create(OutputStream.Stderr);
+
+            AnsiConsole.WriteLine(Marker);
+
+            _stdError.ToString().Should().Contain(Marker);
+            _stdOut.ToString().Should().NotContain(Marker);
+        }
+
+        [TestMethod]
+        public void StaticWritesFollowStdout()
+        {
+            ConsoleFactory.Create(OutputStream.Stdout);
+
+            AnsiConsole.WriteLine(Marker);
+
+            _stdOut.ToString().Should().Contain(Marker);
+            _stdError.ToString().Should().NotContain(Marker);
+        }
+    }
+}

--- a/MSStore.CLI.UnitTests/ConsoleFactoryUnitTests.cs
+++ b/MSStore.CLI.UnitTests/ConsoleFactoryUnitTests.cs
@@ -47,9 +47,9 @@ namespace MSStore.CLI.UnitTests
         }
 
         [TestMethod]
-        public void CreateWritesToStandardErrorForStderr()
+        public void CreateAndInstallWritesToStandardErrorForStderr()
         {
-            var console = ConsoleFactory.Create(OutputStream.Stderr);
+            var console = ConsoleFactory.CreateAndInstall(OutputStream.Stderr);
 
             console.WriteLine(Marker);
 
@@ -58,9 +58,9 @@ namespace MSStore.CLI.UnitTests
         }
 
         [TestMethod]
-        public void CreateWritesToStandardOutputForStdout()
+        public void CreateAndInstallWritesToStandardOutputForStdout()
         {
-            var console = ConsoleFactory.Create(OutputStream.Stdout);
+            var console = ConsoleFactory.CreateAndInstall(OutputStream.Stdout);
 
             console.WriteLine(Marker);
 
@@ -69,9 +69,9 @@ namespace MSStore.CLI.UnitTests
         }
 
         [TestMethod]
-        public void CreateInstallsTheConsoleAsTheStaticConsole()
+        public void CreateAndInstallInstallsTheConsoleAsTheStaticConsole()
         {
-            var console = ConsoleFactory.Create(OutputStream.Stderr);
+            var console = ConsoleFactory.CreateAndInstall(OutputStream.Stderr);
 
             AnsiConsole.Console.Should().BeSameAs(console);
         }
@@ -81,7 +81,7 @@ namespace MSStore.CLI.UnitTests
         {
             // The apps/flights/info tables, the browser launcher and every ConsoleReader prompt write through
             // the static console, so it has to honour the selected stream too.
-            ConsoleFactory.Create(OutputStream.Stderr);
+            ConsoleFactory.CreateAndInstall(OutputStream.Stderr);
 
             AnsiConsole.WriteLine(Marker);
 
@@ -92,7 +92,7 @@ namespace MSStore.CLI.UnitTests
         [TestMethod]
         public void StaticWritesFollowStdout()
         {
-            ConsoleFactory.Create(OutputStream.Stdout);
+            ConsoleFactory.CreateAndInstall(OutputStream.Stdout);
 
             AnsiConsole.WriteLine(Marker);
 

--- a/MSStore.CLI.UnitTests/ConsoleFactoryUnitTests.cs
+++ b/MSStore.CLI.UnitTests/ConsoleFactoryUnitTests.cs
@@ -8,7 +8,8 @@ namespace MSStore.CLI.UnitTests
 {
     /// <summary>
     /// Covers the console that <see cref="Program"/> builds, including the static
-    /// <see cref="AnsiConsole.Console"/> assignment that the tables, prompts and browser launcher depend on.
+    /// <see cref="AnsiConsole.Console"/> assignment that the ConsoleReader prompts and the browser launcher
+    /// confirmation depend on.
     /// </summary>
     [TestClass]
     public class ConsoleFactoryUnitTests
@@ -79,8 +80,8 @@ namespace MSStore.CLI.UnitTests
         [TestMethod]
         public void StaticWritesFollowStderr()
         {
-            // The apps/flights/info tables, the browser launcher and every ConsoleReader prompt write through
-            // the static console, so it has to honour the selected stream too.
+            // The ConsoleReader prompts and the BrowserLauncher confirmation write through the static
+            // console, so it has to honour the selected stream too.
             ConsoleFactory.CreateAndInstall(OutputStream.Stderr);
 
             AnsiConsole.WriteLine(Marker);

--- a/MSStore.CLI.UnitTests/EmptyCommandUnitTests.cs
+++ b/MSStore.CLI.UnitTests/EmptyCommandUnitTests.cs
@@ -47,7 +47,7 @@ namespace MSStore.CLI.UnitTests
 
             var result = await ParseAndInvokeAsync(["info"]);
 
-            result.Output.Should().Contain("Current Config");
+            result.Error.Should().Contain("Current Config");
         }
 
         [TestMethod]
@@ -57,7 +57,7 @@ namespace MSStore.CLI.UnitTests
 
             var result = await ParseAndInvokeAsync(["info"]);
 
-            result.Output.Should().Contain("Current Config");
+            result.Error.Should().Contain("Current Config");
         }
     }
 }

--- a/MSStore.CLI.UnitTests/FlightsCommandUnitTests.cs
+++ b/MSStore.CLI.UnitTests/FlightsCommandUnitTests.cs
@@ -25,8 +25,8 @@ namespace MSStore.CLI.UnitTests
                     FakeApps[0].Id!
                 ]);
 
-            result.Output.Should().ContainAll(FakeFlights.Select(a => a.FlightId));
-            result.Output.Should().ContainAll(FakeFlights.Select(a => a.FriendlyName));
+            result.Error.Should().ContainAll(FakeFlights.Select(a => a.FlightId));
+            result.Error.Should().ContainAll(FakeFlights.Select(a => a.FriendlyName));
         }
 
         [TestMethod]

--- a/MSStore.CLI.UnitTests/OutputStreamProcessTests.cs
+++ b/MSStore.CLI.UnitTests/OutputStreamProcessTests.cs
@@ -1,0 +1,167 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using MSStore.CLI.Services;
+
+namespace MSStore.CLI.UnitTests
+{
+    /// <summary>
+    /// Covers the stream routing configured in <see cref="Program"/>, which the in-process harness cannot
+    /// reach: <see cref="BaseCommandLineTest.ParseAndInvokeAsync"/> builds its own consoles and never runs
+    /// <c>Main</c>. These run the built executable and read stdout and stderr separately.
+    /// </summary>
+    [TestClass]
+    public class OutputStreamProcessTests
+    {
+        // Emitted by Program's "Command is {Command}" log, which only reaches the console under --verbose and
+        // is written through the configured Spectre console, so it lands on whichever stream was selected.
+        private const string HumanOutputMarker = "Command is";
+
+        [TestMethod]
+        public async Task DefaultRoutesHumanReadableOutputToStandardError()
+        {
+            var result = await RunCliAsync(["--verbose", "--help"], null);
+
+            result.StdErr.Should().Contain(HumanOutputMarker);
+            result.StdOut.Should().NotContain(HumanOutputMarker);
+        }
+
+        [DataRow("--output-stream", "stdout")]
+        [DataRow("--output-stream=stdout", null)]
+        [DataRow("--output-stream", "STDOUT")]
+        [TestMethod]
+        public async Task OptionRoutesHumanReadableOutputToStandardOutput(string arg, string? value)
+        {
+            string[] args = value == null
+                ? ["--verbose", arg, "--help"]
+                : ["--verbose", arg, value, "--help"];
+
+            var result = await RunCliAsync(args, null);
+
+            result.StdOut.Should().Contain(HumanOutputMarker);
+            result.StdErr.Should().NotContain(HumanOutputMarker);
+        }
+
+        [TestMethod]
+        public async Task EnvironmentVariableRoutesHumanReadableOutputToStandardOutput()
+        {
+            var result = await RunCliAsync(["--verbose", "--help"], "stdout");
+
+            result.StdOut.Should().Contain(HumanOutputMarker);
+            result.StdErr.Should().NotContain(HumanOutputMarker);
+        }
+
+        [TestMethod]
+        public async Task OptionOverridesTheEnvironmentVariable()
+        {
+            var result = await RunCliAsync(["--verbose", "--output-stream", "stderr", "--help"], "stdout");
+
+            result.StdErr.Should().Contain(HumanOutputMarker);
+            result.StdOut.Should().NotContain(HumanOutputMarker);
+        }
+
+        [TestMethod]
+        public async Task InvalidEnvironmentVariableFallsBackToStandardErrorWithAWarning()
+        {
+            var result = await RunCliAsync(["--verbose", "--help"], "1");
+
+            result.StdErr.Should().Contain(HumanOutputMarker);
+            result.StdErr.Should().Contain(EnvironmentInfo.OutputStreamEnvironmentVariable);
+            result.StdOut.Should().NotContain(HumanOutputMarker);
+        }
+
+        [DataRow(null)]
+        [DataRow("stdout")]
+        [TestMethod]
+        public async Task HelpAlwaysGoesToStandardOutput(string? environmentValue)
+        {
+            // System.CommandLine writes help through InvocationConfiguration.Output, which --output-stream
+            // deliberately leaves alone so that `msstore --help | more` keeps working.
+            var result = await RunCliAsync(["--help"], environmentValue);
+
+            result.ExitCode.Should().Be(0);
+            result.StdOut.Should().Contain("Usage:");
+        }
+
+        private static async Task<(int ExitCode, string StdOut, string StdErr)> RunCliAsync(string[] args, string? outputStreamEnvironmentValue)
+        {
+            var cliPath = FindCliExecutable();
+            if (cliPath == null)
+            {
+                Assert.Inconclusive("The MSStore.CLI executable was not found. Build the solution before running this test.");
+            }
+
+            var startInfo = new ProcessStartInfo(cliPath)
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true
+            };
+
+            foreach (var arg in args)
+            {
+                startInfo.ArgumentList.Add(arg);
+            }
+
+            if (outputStreamEnvironmentValue == null)
+            {
+                // An ambient value on the machine running the tests must not influence the result.
+                startInfo.Environment.Remove(EnvironmentInfo.OutputStreamEnvironmentVariable);
+            }
+            else
+            {
+                startInfo.Environment[EnvironmentInfo.OutputStreamEnvironmentVariable] = outputStreamEnvironmentValue;
+            }
+
+            using var process = Process.Start(startInfo)!;
+
+            var stdOutTask = process.StandardOutput.ReadToEndAsync();
+            var stdErrTask = process.StandardError.ReadToEndAsync();
+
+            using var timeout = new CancellationTokenSource(TimeSpan.FromMinutes(2));
+            try
+            {
+                await process.WaitForExitAsync(timeout.Token);
+            }
+            catch (OperationCanceledException)
+            {
+                process.Kill(entireProcessTree: true);
+                throw;
+            }
+
+            return (process.ExitCode, await stdOutTask, await stdErrTask);
+        }
+
+        private static string? FindCliExecutable()
+        {
+            // The test binary lives in <repo>/MSStore.CLI.UnitTests/bin/<Configuration>/<TargetFramework>,
+            // and the CLI is built alongside it under the same configuration and target framework.
+            var testOutputDirectory = new DirectoryInfo(AppContext.BaseDirectory);
+            var targetFramework = testOutputDirectory.Name;
+            var configuration = testOutputDirectory.Parent?.Name;
+            if (configuration == null)
+            {
+                return null;
+            }
+
+            var repositoryRoot = testOutputDirectory;
+            while (repositoryRoot != null && !File.Exists(Path.Combine(repositoryRoot.FullName, "MSStore.CLI.sln")))
+            {
+                repositoryRoot = repositoryRoot.Parent;
+            }
+
+            if (repositoryRoot == null)
+            {
+                return null;
+            }
+
+            var fileName = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "msstore.exe" : "msstore";
+            var cliPath = Path.Combine(repositoryRoot.FullName, "MSStore.CLI", "bin", configuration, targetFramework, fileName);
+
+            return File.Exists(cliPath) ? cliPath : null;
+        }
+    }
+}

--- a/MSStore.CLI.UnitTests/OutputStreamProcessTests.cs
+++ b/MSStore.CLI.UnitTests/OutputStreamProcessTests.cs
@@ -19,6 +19,63 @@ namespace MSStore.CLI.UnitTests
         // is written through the configured Spectre console, so it lands on whichever stream was selected.
         private const string HumanOutputMarker = "Command is";
 
+        private static readonly List<(string Path, string? Content)> TelemetrySettingsBackups = [];
+
+        /// <summary>
+        /// Program.Main loads (and may rewrite) telemetrySettings.json before it even parses --help. The
+        /// location comes from Environment.GetFolderPath, which ignores LOCALAPPDATA/HOME on Windows, so the
+        /// child cannot simply be pointed at a temporary profile. Snapshot the file instead and put it back,
+        /// so running the suite leaves the real configuration exactly as it found it.
+        /// </summary>
+        /// <param name="context">The test context.</param>
+        [ClassInitialize]
+        public static void BackUpTelemetrySettings(TestContext context)
+        {
+            foreach (var path in TelemetrySettingsPaths())
+            {
+                TelemetrySettingsBackups.Add((path, File.Exists(path) ? File.ReadAllText(path) : null));
+            }
+        }
+
+        [ClassCleanup]
+        public static void RestoreTelemetrySettings()
+        {
+            foreach (var (path, content) in TelemetrySettingsBackups)
+            {
+                if (content == null)
+                {
+                    File.Delete(path);
+                }
+                else
+                {
+                    File.WriteAllText(path, content);
+                }
+            }
+
+            TelemetrySettingsBackups.Clear();
+        }
+
+        private static IEnumerable<string> TelemetrySettingsPaths()
+        {
+            yield return Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+                "Microsoft",
+                "MSStore.CLI",
+                "telemetrySettings.json");
+
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            {
+                // ConfigurationManager prefers the native ApplicationSupportDirectory on macOS.
+                yield return Path.Combine(
+                    Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+                    "Library",
+                    "Application Support",
+                    "Microsoft",
+                    "MSStore.CLI",
+                    "telemetrySettings.json");
+            }
+        }
+
         [TestMethod]
         public async Task DefaultRoutesHumanReadableOutputToStandardError()
         {

--- a/MSStore.CLI.UnitTests/OutputStreamProcessTests.cs
+++ b/MSStore.CLI.UnitTests/OutputStreamProcessTests.cs
@@ -44,12 +44,14 @@ namespace MSStore.CLI.UnitTests
         {
             var result = await RunCliAsync(["--verbose", "--help"], null);
 
+            result.ExitCode.Should().Be(0);
             result.StdErr.Should().Contain(HumanOutputMarker);
             result.StdOut.Should().NotContain(HumanOutputMarker);
         }
 
         [DataRow("--output-stream", "stdout")]
         [DataRow("--output-stream=stdout", null)]
+        [DataRow("--output-stream:stdout", null)]
         [DataRow("--output-stream", "STDOUT")]
         [TestMethod]
         public async Task OptionRoutesHumanReadableOutputToStandardOutput(string arg, string? value)
@@ -60,6 +62,11 @@ namespace MSStore.CLI.UnitTests
 
             var result = await RunCliAsync(args, null);
 
+            // Guards against the command failing for an unrelated reason while the marker still lands on the
+            // right stream. It does not prove the spelling parsed: --help takes precedence over parse errors,
+            // so an unrecognized token here would still exit 0. Parser acceptance of each spelling is covered
+            // in-process by OutputStreamUnitTests, where no help action is involved.
+            result.ExitCode.Should().Be(0);
             result.StdOut.Should().Contain(HumanOutputMarker);
             result.StdErr.Should().NotContain(HumanOutputMarker);
         }
@@ -69,6 +76,7 @@ namespace MSStore.CLI.UnitTests
         {
             var result = await RunCliAsync(["--verbose", "--help"], "stdout");
 
+            result.ExitCode.Should().Be(0);
             result.StdOut.Should().Contain(HumanOutputMarker);
             result.StdErr.Should().NotContain(HumanOutputMarker);
         }
@@ -78,6 +86,7 @@ namespace MSStore.CLI.UnitTests
         {
             var result = await RunCliAsync(["--verbose", "--output-stream", "stderr", "--help"], "stdout");
 
+            result.ExitCode.Should().Be(0);
             result.StdErr.Should().Contain(HumanOutputMarker);
             result.StdOut.Should().NotContain(HumanOutputMarker);
         }
@@ -87,9 +96,22 @@ namespace MSStore.CLI.UnitTests
         {
             var result = await RunCliAsync(["--verbose", "--help"], "1");
 
+            // A malformed environment variable warns and falls back; it must not fail the command.
+            result.ExitCode.Should().Be(0);
             result.StdErr.Should().Contain(HumanOutputMarker);
             result.StdErr.Should().Contain(EnvironmentInfo.OutputStreamEnvironmentVariable);
             result.StdOut.Should().NotContain(HumanOutputMarker);
+        }
+
+        [TestMethod]
+        public async Task InvalidOptionValueIsRejected()
+        {
+            // No --help here: System.CommandLine gives the help action precedence over the parse error, so
+            // `--output-stream console --help` exits 0. The rejection is only observable without it.
+            var result = await RunCliAsync(["--verbose", "--output-stream", "console"], null);
+
+            result.ExitCode.Should().NotBe(0);
+            result.StdErr.Should().Contain("--output-stream");
         }
 
         [DataRow(null)]

--- a/MSStore.CLI.UnitTests/OutputStreamProcessTests.cs
+++ b/MSStore.CLI.UnitTests/OutputStreamProcessTests.cs
@@ -12,6 +12,14 @@ namespace MSStore.CLI.UnitTests
     /// reach: <see cref="BaseCommandLineTest.ParseAndInvokeAsync"/> builds its own consoles and never runs
     /// <c>Main</c>. These run the built executable and read stdout and stderr separately.
     /// </summary>
+    /// <remarks>
+    /// Opt-in through <c>MSSTORE_RUN_PROCESS_TESTS</c>, which CI sets. Running the real executable also runs
+    /// <c>CreateTelemetryClientAsync</c>, which rewrites <c>telemetrySettings.json</c> whenever the telemetry
+    /// GUID is missing or older than 24 hours, and <c>ConfigurationManager</c> resolves that path through
+    /// <see cref="Environment.GetFolderPath(Environment.SpecialFolder)"/>, which ignores <c>LOCALAPPDATA</c>
+    /// and <c>HOME</c> on Windows. There is no way to redirect it at a temporary profile, so rather than
+    /// mutate a developer's real configuration these only run where that is harmless.
+    /// </remarks>
     [TestClass]
     public class OutputStreamProcessTests
     {
@@ -19,60 +27,15 @@ namespace MSStore.CLI.UnitTests
         // is written through the configured Spectre console, so it lands on whichever stream was selected.
         private const string HumanOutputMarker = "Command is";
 
-        private static readonly List<(string Path, string? Content)> TelemetrySettingsBackups = [];
+        private const string OptInEnvironmentVariable = "MSSTORE_RUN_PROCESS_TESTS";
 
-        /// <summary>
-        /// Program.Main loads (and may rewrite) telemetrySettings.json before it even parses --help. The
-        /// location comes from Environment.GetFolderPath, which ignores LOCALAPPDATA/HOME on Windows, so the
-        /// child cannot simply be pointed at a temporary profile. Snapshot the file instead and put it back,
-        /// so running the suite leaves the real configuration exactly as it found it.
-        /// </summary>
-        /// <param name="context">The test context.</param>
-        [ClassInitialize]
-        public static void BackUpTelemetrySettings(TestContext context)
+        [TestInitialize]
+        public void SkipUnlessOptedIn()
         {
-            foreach (var path in TelemetrySettingsPaths())
+            if (string.IsNullOrEmpty(Environment.GetEnvironmentVariable(OptInEnvironmentVariable)))
             {
-                TelemetrySettingsBackups.Add((path, File.Exists(path) ? File.ReadAllText(path) : null));
-            }
-        }
-
-        [ClassCleanup]
-        public static void RestoreTelemetrySettings()
-        {
-            foreach (var (path, content) in TelemetrySettingsBackups)
-            {
-                if (content == null)
-                {
-                    File.Delete(path);
-                }
-                else
-                {
-                    File.WriteAllText(path, content);
-                }
-            }
-
-            TelemetrySettingsBackups.Clear();
-        }
-
-        private static IEnumerable<string> TelemetrySettingsPaths()
-        {
-            yield return Path.Combine(
-                Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
-                "Microsoft",
-                "MSStore.CLI",
-                "telemetrySettings.json");
-
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
-            {
-                // ConfigurationManager prefers the native ApplicationSupportDirectory on macOS.
-                yield return Path.Combine(
-                    Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
-                    "Library",
-                    "Application Support",
-                    "Microsoft",
-                    "MSStore.CLI",
-                    "telemetrySettings.json");
+                Assert.Inconclusive(
+                    $"Set {OptInEnvironmentVariable} to run these tests. They execute the real CLI, which rewrites the telemetry settings of whoever runs them.");
             }
         }
 
@@ -144,13 +107,7 @@ namespace MSStore.CLI.UnitTests
 
         private static async Task<(int ExitCode, string StdOut, string StdErr)> RunCliAsync(string[] args, string? outputStreamEnvironmentValue)
         {
-            var cliPath = FindCliExecutable();
-            if (cliPath == null)
-            {
-                Assert.Inconclusive("The MSStore.CLI executable was not found. Build the solution before running this test.");
-            }
-
-            var startInfo = new ProcessStartInfo(cliPath)
+            var startInfo = new ProcessStartInfo(ResolveCliExecutable())
             {
                 RedirectStandardOutput = true,
                 RedirectStandardError = true,
@@ -192,17 +149,22 @@ namespace MSStore.CLI.UnitTests
             return (process.ExitCode, await stdOutTask, await stdErrTask);
         }
 
-        private static string? FindCliExecutable()
+        /// <summary>
+        /// Locates the CLI built alongside this test assembly.
+        /// </summary>
+        /// <returns>The full path to the executable.</returns>
+        /// <remarks>
+        /// A miss is a failure rather than a skip: these are the only tests covering the real
+        /// <see cref="Program"/> stream wiring, so quietly reporting green would drop that coverage the moment
+        /// the build layout changes.
+        /// </remarks>
+        private static string ResolveCliExecutable()
         {
             // The test binary lives in <repo>/MSStore.CLI.UnitTests/bin/<Configuration>/<TargetFramework>,
             // and the CLI is built alongside it under the same configuration and target framework.
             var testOutputDirectory = new DirectoryInfo(AppContext.BaseDirectory);
             var targetFramework = testOutputDirectory.Name;
             var configuration = testOutputDirectory.Parent?.Name;
-            if (configuration == null)
-            {
-                return null;
-            }
 
             var repositoryRoot = testOutputDirectory;
             while (repositoryRoot != null && !File.Exists(Path.Combine(repositoryRoot.FullName, "MSStore.CLI.sln")))
@@ -210,15 +172,20 @@ namespace MSStore.CLI.UnitTests
                 repositoryRoot = repositoryRoot.Parent;
             }
 
-            if (repositoryRoot == null)
+            if (configuration == null || repositoryRoot == null)
             {
-                return null;
+                Assert.Fail($"Could not locate MSStore.CLI.sln or the build configuration by walking up from '{AppContext.BaseDirectory}'.");
             }
 
             var fileName = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "msstore.exe" : "msstore";
             var cliPath = Path.Combine(repositoryRoot.FullName, "MSStore.CLI", "bin", configuration, targetFramework, fileName);
 
-            return File.Exists(cliPath) ? cliPath : null;
+            if (!File.Exists(cliPath))
+            {
+                Assert.Fail($"The MSStore.CLI executable was not found at '{cliPath}'. Build MSStore.CLI.sln for configuration '{configuration}' and target framework '{targetFramework}' before running these tests.");
+            }
+
+            return cliPath;
         }
     }
 }

--- a/MSStore.CLI.UnitTests/OutputStreamUnitTests.cs
+++ b/MSStore.CLI.UnitTests/OutputStreamUnitTests.cs
@@ -144,6 +144,42 @@ namespace MSStore.CLI.UnitTests
             warning.Should().BeNull();
         }
 
+        [DataRow("0")]
+        [DataRow("1")]
+        [DataRow("2")]
+        [TestMethod]
+        public void ResolveRejectsNumericEnumValues(string environmentValue)
+        {
+            // Only the two names are part of the contract, so the underlying numbers must not be accepted.
+            var (stream, warning) = OutputStreamResolver.Resolve(["publish"], environmentValue);
+
+            stream.Should().Be(OutputStream.Stderr);
+            warning.Should().Contain(environmentValue);
+        }
+
+        [DataRow("--output-stream", "stdout")]
+        [DataRow("--output-stream=stdout", null)]
+        [TestMethod]
+        public void ResolveStopsScanningAtTheEndOfOptionsMarker(string arg, string? value)
+        {
+            // System.CommandLine treats everything after `--` as a literal argument, so the resolver must too.
+            string[] args = value == null ? ["package", "--", arg] : ["package", "--", arg, value];
+
+            var (stream, _) = OutputStreamResolver.Resolve(args, null);
+
+            stream.Should().Be(OutputStream.Stderr);
+        }
+
+        [TestMethod]
+        public void ResolveStillReadsTheOptionBeforeTheEndOfOptionsMarker()
+        {
+            var (stream, _) = OutputStreamResolver.Resolve(
+                ["package", "--output-stream", "stdout", "--", "--output-stream=stderr"],
+                null);
+
+            stream.Should().Be(OutputStream.Stdout);
+        }
+
         [TestMethod]
         public void ResolveReadsTheRealEnvironmentVariable()
         {

--- a/MSStore.CLI.UnitTests/OutputStreamUnitTests.cs
+++ b/MSStore.CLI.UnitTests/OutputStreamUnitTests.cs
@@ -226,5 +226,24 @@ namespace MSStore.CLI.UnitTests
 
             result.Error.Should().Contain("--output-stream");
         }
+
+        [DataRow("0")]
+        [DataRow("1")]
+        [TestMethod]
+        public async Task NumericOutputStreamOptionValueIsRejectedByTheParser(string value)
+        {
+            // The parser and OutputStreamResolver have to agree: the resolver rejects the underlying
+            // numbers, so the option must not silently accept them through the built-in enum converter.
+            var result = await ParseAndInvokeAsync(
+                [
+                    "apps",
+                    "list",
+                    "--output-stream",
+                    value
+                ],
+                1);
+
+            result.Error.Should().Contain("--output-stream");
+        }
     }
 }

--- a/MSStore.CLI.UnitTests/OutputStreamUnitTests.cs
+++ b/MSStore.CLI.UnitTests/OutputStreamUnitTests.cs
@@ -1,0 +1,194 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using MSStore.CLI.Helpers;
+using MSStore.CLI.Services;
+
+namespace MSStore.CLI.UnitTests
+{
+    [TestClass]
+    public class OutputStreamUnitTests : BaseCommandLineTest
+    {
+        [TestInitialize]
+        public void Init()
+        {
+            FakeLogin();
+            AddDefaultFakeAccount();
+            AddFakeApps();
+        }
+
+        [TestCleanup]
+        public void ResetOutputStreamEnvironmentVariable()
+        {
+            Environment.SetEnvironmentVariable(EnvironmentInfo.OutputStreamEnvironmentVariable, null);
+        }
+
+        [TestMethod]
+        public void ResolveDefaultsToStderr()
+        {
+            var (stream, warning) = OutputStreamResolver.Resolve([], null);
+
+            stream.Should().Be(OutputStream.Stderr);
+            warning.Should().BeNull();
+        }
+
+        [DataRow("stdout", nameof(OutputStream.Stdout))]
+        [DataRow("stderr", nameof(OutputStream.Stderr))]
+        [DataRow("STDOUT", nameof(OutputStream.Stdout))]
+        [DataRow("StdErr", nameof(OutputStream.Stderr))]
+        [TestMethod]
+        public void ResolveReadsTheOptionValueCaseInsensitively(string value, string expected)
+        {
+            var (stream, warning) = OutputStreamResolver.Resolve(["publish", "--output-stream", value], null);
+
+            stream.Should().Be(Enum.Parse<OutputStream>(expected));
+            warning.Should().BeNull();
+        }
+
+        [DataRow("--output-stream=stdout")]
+        [DataRow("--output-stream:stdout")]
+        [TestMethod]
+        public void ResolveSupportsInlineValueSeparators(string arg)
+        {
+            var (stream, warning) = OutputStreamResolver.Resolve(["publish", arg], null);
+
+            stream.Should().Be(OutputStream.Stdout);
+            warning.Should().BeNull();
+        }
+
+        [TestMethod]
+        public void ResolveUsesTheLastOccurrenceWhenTheOptionIsRepeated()
+        {
+            var (stream, _) = OutputStreamResolver.Resolve(
+                ["publish", "--output-stream", "stdout", "--output-stream", "stderr"],
+                null);
+
+            stream.Should().Be(OutputStream.Stderr);
+        }
+
+        [TestMethod]
+        public void ResolveIgnoresTheOptionWhenItHasNoValue()
+        {
+            var (stream, warning) = OutputStreamResolver.Resolve(["publish", "--output-stream"], null);
+
+            stream.Should().Be(OutputStream.Stderr);
+            warning.Should().BeNull();
+        }
+
+        [TestMethod]
+        public void ResolveDoesNotMatchOptionsThatMerelyStartWithTheSameText()
+        {
+            var (stream, _) = OutputStreamResolver.Resolve(["package", "--output-streamer", "stdout"], null);
+
+            stream.Should().Be(OutputStream.Stderr);
+        }
+
+        [TestMethod]
+        public void ResolveDoesNotConfuseTheOptionWithTheOutputDirectoryOption()
+        {
+            var (stream, _) = OutputStreamResolver.Resolve(["package", "--output", "C:\\packages"], null);
+
+            stream.Should().Be(OutputStream.Stderr);
+        }
+
+        [TestMethod]
+        public void ResolveReadsTheEnvironmentVariableWhenTheOptionIsAbsent()
+        {
+            var (stream, warning) = OutputStreamResolver.Resolve(["publish"], "stdout");
+
+            stream.Should().Be(OutputStream.Stdout);
+            warning.Should().BeNull();
+        }
+
+        [DataRow("stdout", "stderr", nameof(OutputStream.Stderr))]
+        [DataRow("stderr", "stdout", nameof(OutputStream.Stdout))]
+        [TestMethod]
+        public void ResolveLetsTheOptionOverrideTheEnvironmentVariable(string environmentValue, string optionValue, string expected)
+        {
+            var (stream, warning) = OutputStreamResolver.Resolve(
+                ["package", "--output-stream", optionValue],
+                environmentValue);
+
+            stream.Should().Be(Enum.Parse<OutputStream>(expected));
+            warning.Should().BeNull();
+        }
+
+        [TestMethod]
+        public void ResolveWarnsAndFallsBackWhenTheEnvironmentVariableIsInvalid()
+        {
+            var (stream, warning) = OutputStreamResolver.Resolve(["publish"], "console");
+
+            stream.Should().Be(OutputStream.Stderr);
+            warning.Should().Contain("console");
+            warning.Should().Contain(EnvironmentInfo.OutputStreamEnvironmentVariable);
+        }
+
+        [DataRow("")]
+        [DataRow("   ")]
+        [TestMethod]
+        public void ResolveTreatsABlankEnvironmentVariableAsUnset(string environmentValue)
+        {
+            var (stream, warning) = OutputStreamResolver.Resolve(["publish"], environmentValue);
+
+            stream.Should().Be(OutputStream.Stderr);
+            warning.Should().BeNull();
+        }
+
+        [TestMethod]
+        public void ResolveDoesNotWarnForAnInvalidOptionValue()
+        {
+            // The parser reports invalid option values, so the resolver just falls through.
+            var (stream, warning) = OutputStreamResolver.Resolve(["publish", "--output-stream", "console"], null);
+
+            stream.Should().Be(OutputStream.Stderr);
+            warning.Should().BeNull();
+        }
+
+        [TestMethod]
+        public void ResolveReadsTheRealEnvironmentVariable()
+        {
+            Environment.SetEnvironmentVariable(EnvironmentInfo.OutputStreamEnvironmentVariable, "stdout");
+
+            var (stream, warning) = OutputStreamResolver.Resolve(["publish"]);
+
+            stream.Should().Be(OutputStream.Stdout);
+            warning.Should().BeNull();
+        }
+
+        [DataRow("stdout")]
+        [DataRow("stderr")]
+        [TestMethod]
+        public async Task OutputStreamOptionIsAcceptedByCommands(string value)
+        {
+            var appId = FakeApps[2].Id!;
+
+            var result = await ParseAndInvokeAsync(
+                [
+                    "apps",
+                    "get",
+                    appId,
+                    "--output-stream",
+                    value
+                ]);
+
+            // Machine-readable payloads always go to stdout, whichever stream the human-readable
+            // output was routed to.
+            result.Output.Should().Contain($"\"Id\": \"{appId}\",");
+        }
+
+        [TestMethod]
+        public async Task InvalidOutputStreamOptionValueIsRejectedByTheParser()
+        {
+            var result = await ParseAndInvokeAsync(
+                [
+                    "apps",
+                    "list",
+                    "--output-stream",
+                    "console"
+                ],
+                1);
+
+            result.Error.Should().Contain("--output-stream");
+        }
+    }
+}

--- a/MSStore.CLI.UnitTests/OutputStreamUnitTests.cs
+++ b/MSStore.CLI.UnitTests/OutputStreamUnitTests.cs
@@ -181,6 +181,28 @@ namespace MSStore.CLI.UnitTests
         }
 
         [TestMethod]
+        public void ResolveDoesNotConsumeTheEndOfOptionsMarkerAsTheOptionValue()
+        {
+            // System.CommandLine reports a missing value here and treats the rest as literals, so the
+            // resolver must not take `--` as the value and then pick up the trailing token.
+            var (stream, _) = OutputStreamResolver.Resolve(
+                ["package", "--output-stream", "--", "--output-stream=stdout"],
+                null);
+
+            stream.Should().Be(OutputStream.Stderr);
+        }
+
+        [TestMethod]
+        public void ResolveKeepsAnEarlierValueWhenTheOptionLaterPrecedesTheEndOfOptionsMarker()
+        {
+            var (stream, _) = OutputStreamResolver.Resolve(
+                ["package", "--output-stream=stdout", "--output-stream", "--", "stderr"],
+                null);
+
+            stream.Should().Be(OutputStream.Stdout);
+        }
+
+        [TestMethod]
         public void ResolveReadsTheRealEnvironmentVariable()
         {
             Environment.SetEnvironmentVariable(EnvironmentInfo.OutputStreamEnvironmentVariable, "stdout");

--- a/MSStore.CLI.UnitTests/OutputStreamUnitTests.cs
+++ b/MSStore.CLI.UnitTests/OutputStreamUnitTests.cs
@@ -212,6 +212,30 @@ namespace MSStore.CLI.UnitTests
             result.Output.Should().Contain($"\"Id\": \"{appId}\",");
         }
 
+        [DataRow("--output-stream=stdout")]
+        [DataRow("--output-stream:stdout")]
+        [DataRow("--output-stream=stderr")]
+        [DataRow("--output-stream:stderr")]
+        [TestMethod]
+        public async Task InlineOutputStreamOptionFormsAreAcceptedByCommands(string arg)
+        {
+            // OutputStreamResolver accepts both inline separators, so the parser has to as well. This is
+            // asserted here rather than in the process tests because those pass --help, which takes
+            // precedence over parse errors and would mask an unrecognized token. ParseAndInvokeAsync
+            // asserts an exit code of 0, so a rejected spelling fails.
+            var appId = FakeApps[2].Id!;
+
+            var result = await ParseAndInvokeAsync(
+                [
+                    "apps",
+                    "get",
+                    appId,
+                    arg
+                ]);
+
+            result.Output.Should().Contain($"\"Id\": \"{appId}\",");
+        }
+
         [TestMethod]
         public async Task InvalidOutputStreamOptionValueIsRejectedByTheParser()
         {

--- a/MSStore.CLI/Commands/Apps/ListCommand.cs
+++ b/MSStore.CLI/Commands/Apps/ListCommand.cs
@@ -67,11 +67,11 @@ namespace MSStore.CLI.Commands.Apps
                         i++;
                     }
 
-                    AnsiConsole.Write(table);
+                    _ansiConsole.Write(table);
                     return await _telemetryClient.TrackCommandEventAsync<Handler>(0, ct);
                 }
 
-                AnsiConsole.MarkupLine("Your account has [bold][u]no[/] Managed apps[/].");
+                _ansiConsole.MarkupLine("Your account has [bold][u]no[/] Managed apps[/].");
                 return await _telemetryClient.TrackCommandEventAsync<Handler>(-1, ct);
             }
         }

--- a/MSStore.CLI/Commands/Flights/ListCommand.cs
+++ b/MSStore.CLI/Commands/Flights/ListCommand.cs
@@ -79,7 +79,7 @@ namespace MSStore.CLI.Commands.Flights
                         i++;
                     }
 
-                    AnsiConsole.Write(table);
+                    _ansiConsole.Write(table);
                     return await _telemetryClient.TrackCommandEventAsync<Handler>(0, ct);
                 }
                 else

--- a/MSStore.CLI/Commands/InfoCommand.cs
+++ b/MSStore.CLI/Commands/InfoCommand.cs
@@ -21,9 +21,10 @@ namespace MSStore.CLI.Commands
         {
         }
 
-        public class Handler(IConfigurationManager<Configurations> configurationManager, TelemetryClient telemetryClient, ILogger<InfoCommand.Handler> logger) : AsynchronousCommandLineAction
+        public class Handler(IConfigurationManager<Configurations> configurationManager, IAnsiConsole ansiConsole, TelemetryClient telemetryClient, ILogger<InfoCommand.Handler> logger) : AsynchronousCommandLineAction
         {
             private readonly IConfigurationManager<Configurations> _configurationManager = configurationManager ?? throw new ArgumentNullException(nameof(configurationManager));
+            private readonly IAnsiConsole _ansiConsole = ansiConsole ?? throw new ArgumentNullException(nameof(ansiConsole));
             private readonly TelemetryClient _telemetryClient = telemetryClient ?? throw new ArgumentNullException(nameof(telemetryClient));
             private readonly ILogger _logger = logger ?? throw new ArgumentNullException(nameof(logger));
 
@@ -79,7 +80,7 @@ namespace MSStore.CLI.Commands
                     _logger.LogInformation("Settings File Path: {@SettingsFilePath}", _configurationManager.ConfigPath);
                 }
 
-                AnsiConsole.Write(table);
+                _ansiConsole.Write(table);
 
                 return await _telemetryClient.TrackCommandEventAsync<Handler>(0, ct);
             }

--- a/MSStore.CLI/Helpers/ConsoleFactory.cs
+++ b/MSStore.CLI/Helpers/ConsoleFactory.cs
@@ -1,0 +1,41 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using Spectre.Console;
+
+namespace MSStore.CLI.Helpers
+{
+    /// <summary>
+    /// Builds the console that every human-readable write goes through.
+    /// </summary>
+    internal static class ConsoleFactory
+    {
+        /// <summary>
+        /// Creates the console for <paramref name="outputStream"/> and installs it as the static
+        /// <see cref="AnsiConsole.Console"/>.
+        /// </summary>
+        /// <param name="outputStream">The stream human-readable output should be written to.</param>
+        /// <returns>The console, which is also registered in the service collection.</returns>
+        /// <remarks>
+        /// A handful of call sites still reach for the static console — the apps, flights and info tables, the
+        /// browser launcher, and every <see cref="Services.ConsoleReader"/> prompt. Installing the same
+        /// instance keeps them on the selected stream instead of Spectre's default stdout console, and leaves
+        /// stdout to <see cref="StandardOutput"/>.
+        /// </remarks>
+        public static IAnsiConsole Create(OutputStream outputStream)
+        {
+            var useStdout = outputStream == OutputStream.Stdout;
+
+            var console = AnsiConsole.Create(new AnsiConsoleSettings
+            {
+                Interactive = (useStdout ? Console.IsOutputRedirected : Console.IsErrorRedirected) ? InteractionSupport.No : InteractionSupport.Yes,
+                Out = new AnsiConsoleOutput(useStdout ? Console.Out : Console.Error)
+            });
+
+            AnsiConsole.Console = console;
+
+            return console;
+        }
+    }
+}

--- a/MSStore.CLI/Helpers/ConsoleFactory.cs
+++ b/MSStore.CLI/Helpers/ConsoleFactory.cs
@@ -23,7 +23,7 @@ namespace MSStore.CLI.Helpers
         /// instance keeps them on the selected stream instead of Spectre's default stdout console, and leaves
         /// stdout to <see cref="StandardOutput"/>.
         /// </remarks>
-        public static IAnsiConsole Create(OutputStream outputStream)
+        public static IAnsiConsole CreateAndInstall(OutputStream outputStream)
         {
             var useStdout = outputStream == OutputStream.Stdout;
 

--- a/MSStore.CLI/Helpers/ConsoleFactory.cs
+++ b/MSStore.CLI/Helpers/ConsoleFactory.cs
@@ -18,10 +18,10 @@ namespace MSStore.CLI.Helpers
         /// <param name="outputStream">The stream human-readable output should be written to.</param>
         /// <returns>The console, which is also registered in the service collection.</returns>
         /// <remarks>
-        /// A handful of call sites still reach for the static console — the apps, flights and info tables, the
-        /// browser launcher, and every <see cref="Services.ConsoleReader"/> prompt. Installing the same
-        /// instance keeps them on the selected stream instead of Spectre's default stdout console, and leaves
-        /// stdout to <see cref="StandardOutput"/>.
+        /// The <see cref="Services.ConsoleReader"/> prompts and the <see cref="Services.BrowserLauncher"/>
+        /// confirmation still reach for the static console. Installing the same instance keeps them on the
+        /// selected stream instead of Spectre's default stdout console, and leaves stdout to
+        /// <see cref="StandardOutput"/>.
         /// </remarks>
         public static IAnsiConsole CreateAndInstall(OutputStream outputStream)
         {

--- a/MSStore.CLI/Helpers/OutputStream.cs
+++ b/MSStore.CLI/Helpers/OutputStream.cs
@@ -1,0 +1,27 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace MSStore.CLI.Helpers
+{
+    /// <summary>
+    /// The standard stream that human-readable console output is written to.
+    /// </summary>
+    /// <remarks>
+    /// This never affects machine-readable payloads, which always go to stdout through
+    /// <see cref="StandardOutput"/>.
+    /// </remarks>
+    internal enum OutputStream
+    {
+        /// <summary>
+        /// Human-readable output goes to standard error. This is the default, and keeps stdout
+        /// clean so payloads can be piped or captured.
+        /// </summary>
+        Stderr,
+
+        /// <summary>
+        /// Human-readable output goes to standard output. Useful on Azure DevOps, which renders
+        /// every stderr line as <c>##[error]</c>.
+        /// </summary>
+        Stdout
+    }
+}

--- a/MSStore.CLI/Helpers/OutputStreamResolver.cs
+++ b/MSStore.CLI/Helpers/OutputStreamResolver.cs
@@ -1,0 +1,131 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using MSStore.CLI.Services;
+
+namespace MSStore.CLI.Helpers
+{
+    /// <summary>
+    /// Resolves which standard stream human-readable output should be written to.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The resolution order is <c>--output-stream</c> &gt; <see cref="EnvironmentInfo.OutputStreamEnvironmentVariable"/>
+    /// &gt; <see cref="OutputStream.Stderr"/>. The flag deliberately wins so that a pipeline-wide environment
+    /// variable can be overridden on the individual commands that emit a machine-readable payload.
+    /// </para>
+    /// <para>
+    /// <see cref="Program"/> has to build the <see cref="Spectre.Console.IAnsiConsole"/> before the command line is
+    /// parsed, because the host builder needs it in the service collection. The raw arguments are therefore
+    /// inspected here, the same way <c>--verbose</c> is handled.
+    /// </para>
+    /// </remarks>
+    internal static class OutputStreamResolver
+    {
+        internal const string OptionName = "--output-stream";
+
+        private static readonly char[] InlineValueSeparators = [':', '='];
+
+        /// <summary>
+        /// Resolves the stream from the raw command line arguments and the environment.
+        /// </summary>
+        /// <param name="args">The raw command line arguments.</param>
+        /// <returns>The resolved stream, and a warning to surface when the environment variable is malformed.</returns>
+        public static (OutputStream Stream, string? Warning) Resolve(IReadOnlyList<string> args)
+        {
+            string? environmentValue;
+            try
+            {
+                environmentValue = Environment.GetEnvironmentVariable(EnvironmentInfo.OutputStreamEnvironmentVariable);
+            }
+            catch (Exception)
+            {
+                // Reading the environment can throw under restricted hosts. Fall back to the default.
+                environmentValue = null;
+            }
+
+            return Resolve(args, environmentValue);
+        }
+
+        /// <summary>
+        /// Resolves the stream from the raw command line arguments and an explicit environment variable value.
+        /// </summary>
+        /// <param name="args">The raw command line arguments.</param>
+        /// <param name="environmentValue">The value of the environment variable, or null when it is not set.</param>
+        /// <returns>The resolved stream, and a warning to surface when the environment variable is malformed.</returns>
+        public static (OutputStream Stream, string? Warning) Resolve(IReadOnlyList<string> args, string? environmentValue)
+        {
+            ArgumentNullException.ThrowIfNull(args);
+
+            if (TryParse(FindOptionValue(args), out var fromArgs))
+            {
+                return (fromArgs, null);
+            }
+
+            if (string.IsNullOrWhiteSpace(environmentValue))
+            {
+                return (OutputStream.Stderr, null);
+            }
+
+            if (TryParse(environmentValue, out var fromEnvironment))
+            {
+                return (fromEnvironment, null);
+            }
+
+            return (
+                OutputStream.Stderr,
+                $"'{environmentValue}' is not a valid {EnvironmentInfo.OutputStreamEnvironmentVariable} value. Expected '{nameof(OutputStream.Stdout)}' or '{nameof(OutputStream.Stderr)}'. Falling back to '{nameof(OutputStream.Stderr)}'.");
+        }
+
+        /// <summary>
+        /// Parses a stream name, accepting any casing.
+        /// </summary>
+        /// <param name="value">The value to parse.</param>
+        /// <param name="outputStream">The parsed stream.</param>
+        /// <returns>True when the value names a known stream.</returns>
+        public static bool TryParse(string? value, out OutputStream outputStream)
+        {
+            outputStream = OutputStream.Stderr;
+
+            return !string.IsNullOrWhiteSpace(value)
+                && Enum.TryParse(value.Trim(), ignoreCase: true, out outputStream)
+                && Enum.IsDefined(outputStream);
+        }
+
+        /// <summary>
+        /// Finds the value of the last <c>--output-stream</c> occurrence, supporting both the
+        /// <c>--output-stream value</c> and <c>--output-stream=value</c> forms.
+        /// </summary>
+        /// <param name="args">The raw command line arguments.</param>
+        /// <returns>The value, or null when the option is absent.</returns>
+        private static string? FindOptionValue(IReadOnlyList<string> args)
+        {
+            string? value = null;
+
+            for (var i = 0; i < args.Count; i++)
+            {
+                var arg = args[i];
+                if (arg == null)
+                {
+                    continue;
+                }
+
+                if (arg.Length > OptionName.Length
+                    && arg.StartsWith(OptionName, StringComparison.Ordinal)
+                    && Array.IndexOf(InlineValueSeparators, arg[OptionName.Length]) >= 0)
+                {
+                    value = arg[(OptionName.Length + 1)..];
+                }
+                else if (string.Equals(arg, OptionName, StringComparison.Ordinal) && i + 1 < args.Count)
+                {
+                    value = args[i + 1];
+                    i++;
+                }
+            }
+
+            return value;
+        }
+    }
+}

--- a/MSStore.CLI/Helpers/OutputStreamResolver.cs
+++ b/MSStore.CLI/Helpers/OutputStreamResolver.cs
@@ -26,6 +26,8 @@ namespace MSStore.CLI.Helpers
     {
         internal const string OptionName = "--output-stream";
 
+        private const string EndOfOptions = "--";
+
         private static readonly char[] InlineValueSeparators = [':', '='];
 
         /// <summary>
@@ -85,13 +87,28 @@ namespace MSStore.CLI.Helpers
         /// <param name="value">The value to parse.</param>
         /// <param name="outputStream">The parsed stream.</param>
         /// <returns>True when the value names a known stream.</returns>
+        /// <remarks>
+        /// Only the two names are accepted. <see cref="Enum.TryParse{TEnum}(string, bool, out TEnum)"/> would also
+        /// accept the underlying numeric values, which are not part of the documented contract.
+        /// </remarks>
         public static bool TryParse(string? value, out OutputStream outputStream)
         {
             outputStream = OutputStream.Stderr;
 
-            return !string.IsNullOrWhiteSpace(value)
-                && Enum.TryParse(value.Trim(), ignoreCase: true, out outputStream)
-                && Enum.IsDefined(outputStream);
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                return false;
+            }
+
+            var name = value.Trim();
+
+            if (string.Equals(name, nameof(OutputStream.Stdout), StringComparison.OrdinalIgnoreCase))
+            {
+                outputStream = OutputStream.Stdout;
+                return true;
+            }
+
+            return string.Equals(name, nameof(OutputStream.Stderr), StringComparison.OrdinalIgnoreCase);
         }
 
         /// <summary>
@@ -100,6 +117,10 @@ namespace MSStore.CLI.Helpers
         /// </summary>
         /// <param name="args">The raw command line arguments.</param>
         /// <returns>The value, or null when the option is absent.</returns>
+        /// <remarks>
+        /// Scanning stops at a standalone <c>--</c>, because System.CommandLine treats everything after it as
+        /// literal arguments rather than options.
+        /// </remarks>
         private static string? FindOptionValue(IReadOnlyList<string> args)
         {
             string? value = null;
@@ -110,6 +131,11 @@ namespace MSStore.CLI.Helpers
                 if (arg == null)
                 {
                     continue;
+                }
+
+                if (string.Equals(arg, EndOfOptions, StringComparison.Ordinal))
+                {
+                    break;
                 }
 
                 if (arg.Length > OptionName.Length

--- a/MSStore.CLI/Helpers/OutputStreamResolver.cs
+++ b/MSStore.CLI/Helpers/OutputStreamResolver.cs
@@ -146,6 +146,14 @@ namespace MSStore.CLI.Helpers
                 }
                 else if (string.Equals(arg, OptionName, StringComparison.Ordinal) && i + 1 < args.Count)
                 {
+                    // System.CommandLine treats a following `--` as the end-of-options marker rather than a
+                    // value, and reports the option's value as missing. Stop rather than consuming the marker
+                    // and carrying on past it, which would pick up a later literal the parser never accepts.
+                    if (string.Equals(args[i + 1], EndOfOptions, StringComparison.Ordinal))
+                    {
+                        break;
+                    }
+
                     value = args[i + 1];
                     i++;
                 }

--- a/MSStore.CLI/Helpers/StandardOutput.cs
+++ b/MSStore.CLI/Helpers/StandardOutput.cs
@@ -12,9 +12,16 @@ namespace MSStore.CLI.Helpers
         /// </summary>
         /// <param name="value">The text to write.</param>
         /// <remarks>
+        /// <para>
         /// This deliberately bypasses Spectre.Console's <see cref="Spectre.Console.AnsiConsole"/>: its renderer
         /// word-wraps at the console width (falling back to 80 columns when stdout is redirected), which injects
         /// raw newline characters inside JSON string values and produces invalid JSON.
+        /// </para>
+        /// <para>
+        /// Machine-readable payloads always go to stdout, regardless of <c>--output-stream</c>. Pass
+        /// <c>--output-stream stderr</c> on these commands when a pipeline-wide
+        /// <c>MSSTORE_OUTPUT_STREAM=stdout</c> would otherwise interleave human-readable output with the payload.
+        /// </para>
         /// </remarks>
         public static void WriteLine(string value)
         {

--- a/MSStore.CLI/MicrosoftStoreCLI.cs
+++ b/MSStore.CLI/MicrosoftStoreCLI.cs
@@ -33,7 +33,24 @@ namespace MSStore.CLI
 
             OutputStreamOption = new Option<OutputStream>(OutputStreamResolver.OptionName)
             {
-                Description = $"The stream that human-readable progress and status output is written to. Defaults to '{nameof(OutputStream.Stderr)}', which keeps stdout for machine-readable payloads. Use '{nameof(OutputStream.Stdout)}' on Azure DevOps, which reports every stderr line as an error. Also settable through the {EnvironmentInfo.OutputStreamEnvironmentVariable} environment variable, which this option overrides."
+                Description = $"The stream that human-readable progress and status output is written to. Defaults to '{nameof(OutputStream.Stderr)}', which keeps stdout for machine-readable payloads. Use '{nameof(OutputStream.Stdout)}' on Azure DevOps, which reports every stderr line as an error. Also settable through the {EnvironmentInfo.OutputStreamEnvironmentVariable} environment variable, which this option overrides.",
+
+                // The built-in enum converter also accepts the underlying numbers, which OutputStreamResolver
+                // rejects. That would let "--output-stream 1" parse as Stdout while the resolver, which is what
+                // actually selects the stream before the host is built, fell back to Stderr. Both sides share
+                // TryParse so there is a single contract. The arity is ExactlyOne, so a missing value fails to
+                // parse before this runs.
+                CustomParser = result =>
+                {
+                    var value = result.Tokens[0].Value;
+                    if (OutputStreamResolver.TryParse(value, out var outputStream))
+                    {
+                        return outputStream;
+                    }
+
+                    result.AddError($"Cannot parse argument '{value}' for option '{OutputStreamResolver.OptionName}'. Expected '{nameof(OutputStream.Stdout)}' or '{nameof(OutputStream.Stderr)}'.");
+                    return OutputStream.Stderr;
+                }
             };
         }
 

--- a/MSStore.CLI/MicrosoftStoreCLI.cs
+++ b/MSStore.CLI/MicrosoftStoreCLI.cs
@@ -33,7 +33,7 @@ namespace MSStore.CLI
 
             OutputStreamOption = new Option<OutputStream>(OutputStreamResolver.OptionName)
             {
-                Description = $"The stream that human-readable output is written to. Defaults to '{nameof(OutputStream.Stderr)}', which keeps stdout free for machine-readable payloads. Use '{nameof(OutputStream.Stdout)}' on Azure DevOps, which reports every stderr line as an error. Also settable through the {EnvironmentInfo.OutputStreamEnvironmentVariable} environment variable, which this option overrides."
+                Description = $"The stream that human-readable progress and status output is written to. Defaults to '{nameof(OutputStream.Stderr)}', which keeps stdout for machine-readable payloads. Use '{nameof(OutputStream.Stdout)}' on Azure DevOps, which reports every stderr line as an error. Also settable through the {EnvironmentInfo.OutputStreamEnvironmentVariable} environment variable, which this option overrides."
             };
         }
 

--- a/MSStore.CLI/MicrosoftStoreCLI.cs
+++ b/MSStore.CLI/MicrosoftStoreCLI.cs
@@ -21,12 +21,19 @@ namespace MSStore.CLI
     {
         internal static Option<bool> VerboseOption { get; }
 
+        internal static Option<OutputStream> OutputStreamOption { get; }
+
         static MicrosoftStoreCLI()
         {
             VerboseOption = new Option<bool>("--verbose", "-v")
             {
                 DefaultValueFactory = _ => false,
                 Description = "Verbose output"
+            };
+
+            OutputStreamOption = new Option<OutputStream>(OutputStreamResolver.OptionName)
+            {
+                Description = $"The stream that human-readable output is written to. Defaults to '{nameof(OutputStream.Stderr)}', which keeps stdout free for machine-readable payloads. Use '{nameof(OutputStream.Stdout)}' on Azure DevOps, which reports every stderr line as an error. Also settable through the {EnvironmentInfo.OutputStreamEnvironmentVariable} environment variable, which this option overrides."
             };
         }
 

--- a/MSStore.CLI/Program.cs
+++ b/MSStore.CLI/Program.cs
@@ -60,6 +60,11 @@ namespace MSStore.CLI
                 Out = new AnsiConsoleOutput(useStdout ? Console.Out : Console.Error)
             });
 
+            // A handful of call sites (list/info tables, prompts, the browser launcher) still reach for the
+            // static console. Point it at the same instance so every human-readable write honours the
+            // selected stream, and stdout is left to StandardOutput.
+            AnsiConsole.Console = ansiConsole;
+
             if (outputStreamWarning != null)
             {
                 ansiConsole.MarkupLine($":warning: {outputStreamWarning.EscapeMarkup()}");

--- a/MSStore.CLI/Program.cs
+++ b/MSStore.CLI/Program.cs
@@ -255,6 +255,9 @@ namespace MSStore.CLI
                 parseError.ShowHelp = true;
             }
 
+            // InvocationConfiguration is left at its defaults on purpose, so --output-stream does not move it:
+            // help goes to stdout so that `msstore --help | more` works, and parse diagnostics go to stderr
+            // because they accompany a non-zero exit code.
             var result = await parseResult.InvokeAsync(parseResult.InvocationConfiguration, lifetime.ApplicationStopping);
 
             await host.StopAsync();

--- a/MSStore.CLI/Program.cs
+++ b/MSStore.CLI/Program.cs
@@ -53,17 +53,7 @@ namespace MSStore.CLI
             TelemetryConfigurations telemetryConfigurations = await telemetryConfigurationManager.LoadAsync(true, CancellationToken.None);
             TelemetryClient telemetryClient = await CreateTelemetryClientAsync(telemetryConfigurationManager, telemetryConfigurations);
             var (outputStream, outputStreamWarning) = OutputStreamResolver.Resolve(args);
-            var useStdout = outputStream == OutputStream.Stdout;
-            var ansiConsole = AnsiConsole.Create(new()
-            {
-                Interactive = (useStdout ? Console.IsOutputRedirected : Console.IsErrorRedirected) ? InteractionSupport.No : InteractionSupport.Yes,
-                Out = new AnsiConsoleOutput(useStdout ? Console.Out : Console.Error)
-            });
-
-            // A handful of call sites (list/info tables, prompts, the browser launcher) still reach for the
-            // static console. Point it at the same instance so every human-readable write honours the
-            // selected stream, and stdout is left to StandardOutput.
-            AnsiConsole.Console = ansiConsole;
+            var ansiConsole = ConsoleFactory.Create(outputStream);
 
             if (outputStreamWarning != null)
             {

--- a/MSStore.CLI/Program.cs
+++ b/MSStore.CLI/Program.cs
@@ -52,11 +52,18 @@ namespace MSStore.CLI
                                 null);
             TelemetryConfigurations telemetryConfigurations = await telemetryConfigurationManager.LoadAsync(true, CancellationToken.None);
             TelemetryClient telemetryClient = await CreateTelemetryClientAsync(telemetryConfigurationManager, telemetryConfigurations);
+            var (outputStream, outputStreamWarning) = OutputStreamResolver.Resolve(args);
+            var useStdout = outputStream == OutputStream.Stdout;
             var ansiConsole = AnsiConsole.Create(new()
             {
-                Interactive = Console.IsErrorRedirected ? InteractionSupport.No : InteractionSupport.Yes,
-                Out = new AnsiConsoleOutput(Console.Error)
+                Interactive = (useStdout ? Console.IsOutputRedirected : Console.IsErrorRedirected) ? InteractionSupport.No : InteractionSupport.Yes,
+                Out = new AnsiConsoleOutput(useStdout ? Console.Out : Console.Error)
             });
+
+            if (outputStreamWarning != null)
+            {
+                ansiConsole.MarkupLine($":warning: {outputStreamWarning.EscapeMarkup()}");
+            }
 
             if (args.Contains(MicrosoftStoreCLI.VerboseOption.Name) || args.Any(MicrosoftStoreCLI.VerboseOption.Aliases.Contains))
             {

--- a/MSStore.CLI/Program.cs
+++ b/MSStore.CLI/Program.cs
@@ -53,7 +53,7 @@ namespace MSStore.CLI
             TelemetryConfigurations telemetryConfigurations = await telemetryConfigurationManager.LoadAsync(true, CancellationToken.None);
             TelemetryClient telemetryClient = await CreateTelemetryClientAsync(telemetryConfigurationManager, telemetryConfigurations);
             var (outputStream, outputStreamWarning) = OutputStreamResolver.Resolve(args);
-            var ansiConsole = ConsoleFactory.Create(outputStream);
+            var ansiConsole = ConsoleFactory.CreateAndInstall(outputStream);
 
             if (outputStreamWarning != null)
             {

--- a/MSStore.CLI/Services/EnvironmentInfo.cs
+++ b/MSStore.CLI/Services/EnvironmentInfo.cs
@@ -28,6 +28,9 @@ namespace MSStore.CLI.Services
         // Environment variable for client assertion file path, used for authentication.
         public static readonly string ClientAssertionFileEnvironmentVariable = "MSSTORE_CLIENT_ASSERTION_FILE";
 
+        // Environment variable that selects the standard stream used for human-readable output.
+        public static readonly string OutputStreamEnvironmentVariable = "MSSTORE_OUTPUT_STREAM";
+
         // Cached environment information, loaded only once
         private static readonly Lazy<string> _cachedEnvironmentInfo = new Lazy<string>(ComputeEnvironmentInfo);
 

--- a/MSStore.CLI/StoreHostBuilderExtensions.cs
+++ b/MSStore.CLI/StoreHostBuilderExtensions.cs
@@ -109,6 +109,7 @@ namespace MSStore.CLI
                 {
                     var command = ActivatorUtilities.CreateInstance<TCommand>(sp);
                     command.Options.Add(MicrosoftStoreCLI.VerboseOption);
+                    command.Options.Add(MicrosoftStoreCLI.OutputStreamOption);
                     command.SetAction((parseResult, ct) => sp.GetRequiredService<THandler>().InvokeAsync(parseResult, ct));
                     return command;
                 });
@@ -122,6 +123,7 @@ namespace MSStore.CLI
                 {
                     var command = ActivatorUtilities.CreateInstance<TCommand>(sp);
                     command.Options.Add(MicrosoftStoreCLI.VerboseOption);
+                    command.Options.Add(MicrosoftStoreCLI.OutputStreamOption);
                     return command;
                 });
         }

--- a/README.md
+++ b/README.md
@@ -10,10 +10,12 @@ The Microsoft Store Developer Command Line Interface is a cross-platform (Window
 
 ## Standard output vs. standard error
 
-The CLI keeps its two output streams separate:
+By default the CLI keeps its two output streams separate:
 
 * **stdout** carries only machine-readable payloads — the JSON emitted by commands such as `submission get`, `apps get` and `submission rollout get`, and the package path printed by `package`. This keeps `msstore submission get ... | ConvertFrom-Json` and `$(msstore package ...)` reliable.
 * **stderr** carries everything meant for a human — progress, status, success messages, tables and verbose logging.
+
+`--output-stream stdout` deliberately breaks that separation: it moves the human-readable half onto stdout, where it is interleaved with any payload. Machine-readable payloads are always written to stdout and are never affected by the option.
 
 ### Azure DevOps
 

--- a/README.md
+++ b/README.md
@@ -10,12 +10,17 @@ The Microsoft Store Developer Command Line Interface is a cross-platform (Window
 
 ## Standard output vs. standard error
 
-By default the CLI keeps its two output streams separate:
+By default the CLI splits its output as follows:
 
-* **stdout** carries only machine-readable payloads — the JSON emitted by commands such as `submission get`, `apps get` and `submission rollout get`, and the package path printed by `package`. This keeps `msstore submission get ... | ConvertFrom-Json` and `$(msstore package ...)` reliable.
-* **stderr** carries everything meant for a human — progress, status, success messages, tables and verbose logging.
+* **stdout** carries the command's result — machine-readable payloads such as the JSON emitted by `submission get`, `apps get` and `submission rollout get`, the package path printed by `package`, and `--help` text. This keeps `msstore submission get ... | ConvertFrom-Json` and `$(msstore package ...)` reliable.
+* **stderr** carries everything else meant for a human — progress, status, success messages, tables, prompts and verbose logging.
 
-`--output-stream stdout` deliberately breaks that separation: it moves the human-readable half onto stdout, where it is interleaved with any payload. Machine-readable payloads are always written to stdout and are never affected by the option.
+`--output-stream stdout` deliberately breaks that separation: it moves the human-readable half onto stdout, where it is interleaved with any payload.
+
+Two things sit outside the option's scope on purpose, matching the behavior of other CLIs:
+
+* Machine-readable payloads are always written to stdout, so they are never affected by the option.
+* `--help` is always written to stdout, so that `msstore --help | more` works, and command line parse errors are always written to stderr, because they accompany a non-zero exit code.
 
 ### Azure DevOps
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,47 @@ The Microsoft Store Developer Command Line Interface is a cross-platform (Window
 ## Helpful links
 * [Documentation](https://aka.ms/msstoredevcli/docs) - Microsoft's official documentation on regards to available commands, installation steps, how to properly setup CI/CD environments, and general guidance.
 
+## Standard output vs. standard error
+
+The CLI keeps its two output streams separate:
+
+* **stdout** carries only machine-readable payloads — the JSON emitted by commands such as `submission get`, `apps get` and `submission rollout get`, and the package path printed by `package`. This keeps `msstore submission get ... | ConvertFrom-Json` and `$(msstore package ...)` reliable.
+* **stderr** carries everything meant for a human — progress, status, success messages, tables and verbose logging.
+
+### Azure DevOps
+
+Azure DevOps reports every stderr line as `##[error]`, even when the command succeeded and even when the task sets `failOnStderr: false`. A successful `msstore publish` therefore shows up as a failed or partially failed stage.
+
+To avoid this, move the human-readable output to stdout:
+
+```yaml
+- script: msstore publish ./MyApp --output-stream stdout
+  displayName: Publish to the Microsoft Store
+```
+
+Or set it once for a whole job, so that every `msstore` call picks it up:
+
+```yaml
+variables:
+  MSSTORE_OUTPUT_STREAM: stdout
+```
+
+> [!IMPORTANT]
+> Machine-readable payloads always go to stdout. When `MSSTORE_OUTPUT_STREAM` is set for a whole job, the human-readable output is interleaved with the payload, which breaks capturing it. Pass `--output-stream stderr` on those specific calls to opt back out — the option always overrides the environment variable:
+>
+> ```yaml
+> variables:
+>   MSSTORE_OUTPUT_STREAM: stdout
+>
+> steps:
+> - script: msstore publish ./MyApp                                   # human-readable output on stdout
+> - script: msstore submission get $(AppId) --output-stream stderr    # clean JSON on stdout
+> ```
+
+### GitHub Actions
+
+No change is needed. GitHub Actions fails a step based on its exit code alone and never turns stderr into an error annotation, so the default is already correct.
+
 ## Contributing
 
 This project welcomes contributions and suggestions.  Most contributions require you to agree to a


### PR DESCRIPTION
Fixes #161

## Problem

`Program.cs` builds the single `IAnsiConsole` over `Console.Error`, so **every** human-facing message — success ticks, status lines, tables, and everything from `CustomSpectreConsoleLogger` — goes to stderr.

Azure DevOps renders any stderr line as `##[error]`, so a fully successful `msstore publish` reports as a failed or partially failed release stage.

Documenting `failOnStderr: false` does **not** fix this: Azure DevOps still prints `##[error]` for stderr lines even when the task is configured not to fail on them ([azure-pipelines-tasks#16825](https://github.com/microsoft/azure-pipelines-tasks/issues/16825), [#13097](https://github.com/microsoft/azure-pipelines-tasks/issues/13097)).

## Why this is opt-in rather than a changed default

The stderr routing is deliberate (commit `ca1d6ab`, PR #158 / issue #150): stdout is reserved for machine-readable payloads — the 19 `StandardOutput.WriteLine` JSON sites plus the `package` output path. Flipping the default would break `msstore submission get | ConvertFrom-Json` and `$(msstore package)`.

Prior art agrees the default is right: `gh` puts progress on stderr (gated on `IsStdoutTTY()`), and `az`, `terraform`, `aws`, `npm`, `pip`, `docker` and `dotnet` all do the same with no way to switch streams. GitHub Actions is unaffected either way — it fails on exit code only and never annotates stderr.

## Change

A global `--output-stream <stderr|stdout>` option, backed by the `MSSTORE_OUTPUT_STREAM` environment variable so a pipeline can opt in once at job scope.

```yaml
# per call
- script: msstore publish ./MyApp --output-stream stdout

# or once for the whole job
variables:
  MSSTORE_OUTPUT_STREAM: stdout
```

Resolution is **option > environment variable > `stderr`**. The option deliberately wins, because a job-wide environment variable is the one real hazard here — it would interleave human output with the payload on the commands that emit one. Those calls opt back out locally:

```yaml
- script: msstore submission get $(AppId) --output-stream stderr   # clean JSON on stdout
```

`StandardOutput` is untouched, so payloads always go to stdout either way.

Implementation notes:
- The console must exist before the real command line is parsed, since the host builder needs it in the service collection. `OutputStreamResolver` therefore parses the option against a throwaway `RootCommand` carrying only `MicrosoftStoreCLI.OutputStreamOption`, which is a static with no dependencies. `TreatUnmatchedTokensAsErrors = false` makes subcommands, positionals and other options harmless. Delegating to the parser keeps inline separators, casing, repeats and the `--` end-of-options marker consistent with the real parse rather than reimplementing them.
- The option uses a `CustomParser` backed by the same `TryParse` as the environment variable, so neither route accepts the enum's underlying numbers.
- `ConsoleFactory.CreateAndInstall` builds the console and installs it as the static `AnsiConsole.Console`, so the `ConsoleReader` prompts and the `BrowserLauncher` confirmation honour the selected stream.
- Interactivity probes whichever stream is actually in use (`Console.IsOutputRedirected` vs `Console.IsErrorRedirected`).

## ⚠️ Behavior change

The call sites that reached for the **static** `AnsiConsole` were writing to stdout: the `apps list` / `flights list` / `info` tables, the `BrowserLauncher` prompt, and every `ConsoleReader` prompt. Those now go to stderr with the rest of the human-readable output.

| Output | Before | After |
| --- | --- | --- |
| `apps list`, `flights list`, `info` tables | **stdout** | stderr (or stdout with `--output-stream stdout`) |
| interactive prompts, browser confirmation | **stdout** | stderr |
| progress, status, success, verbose logging | stderr | stderr — unchanged |
| `apps get`, `flights get`, `submission get`, `package` payloads | stdout | stdout — unchanged |

Verified by building the base commit and diffing actual behaviour, not from the diff.

Note that `--output-stream stdout` is **not** a return to the old routing: it puts *all* human-readable output on stdout, including the progress and status that was already on stderr. `2>&1` is the faithful recovery for a script that just wants its table back. The README carries this.

## Scope

`--help` stays on stdout so `msstore --help | more` keeps working, and parse errors stay on stderr because they accompany a non-zero exit code. Both are written through `InvocationConfiguration`, which is deliberately left at its defaults.

## Verification

Behaviour confirmed against the built binary, comparing separately-redirected stdout/stderr:

| Invocation | Human output lands on |
| --- | --- |
| *(default)* | stderr |
| `--output-stream stdout` | stdout |
| `--output-stream=stdout` / `--output-stream:stdout` | stdout |
| `--output-stream STDOUT` | stdout |
| `MSSTORE_OUTPUT_STREAM=stdout` | stdout |
| `MSSTORE_OUTPUT_STREAM=stdout` + `--output-stream stderr` | stderr |
| `MSSTORE_OUTPUT_STREAM=bogus` or `=1` | stderr, with a warning |
| `-- --output-stream=stdout` (after end-of-options) | stderr — ignored, matching the parser |
| `--output-stream -- ...` | stderr — parser rejects it, so routing is not taken from it |
| repeated `--output-stream` | stderr — parser rejects it, so routing is not taken from it |

Tests across three classes:

- resolver/parser unit tests
- `ConsoleFactoryUnitTests` for the stream selection and the static-console install
- `OutputStreamProcessTests`, which runs the built executable and reads the two streams separately

`OutputStreamProcessTests` is **opt-in through `MSSTORE_RUN_PROCESS_TESTS`**, which both CI definitions set on every test step. Running the real CLI also runs `CreateTelemetryClientAsync`, which can rewrite `telemetrySettings.json`, and `ConfigurationManager` resolves that path via `Environment.GetFolderPath`, which ignores `LOCALAPPDATA`/`HOME` on Windows — so it cannot be redirected at a temp profile. Rather than snapshot and restore a developer's real config (which is not crash-safe if the host is killed mid-run), these only run where the mutation is harmless. All runners used here are ephemeral and hosted. Verified from the CI TRX artifacts that all 9 run and pass on Windows, Ubuntu and macOS.

Both new test classes were mutation-checked: reverting the `Out` selector to `Console.Error` fails 4 process tests, and deleting the `AnsiConsole.Console` assignment fails 3 factory tests. Removing the built executable fails all 9 process tests with the probed path, rather than skipping.

Full suite is 249/249 on `net10.0-windows10.0.17763.0`. On `net10.0` the only 2 failures (`PublishCommandFor{WinUI,Maui}AppsShouldCallMSBuildIfWindows`) reproduce identically on a stashed clean tree, so they are pre-existing and environmental — both pass in CI. Release build is warning-free under `TreatWarningsAsErrors`, and ILC reports no trim/AOT warnings.