### PR TITLE
Preserve the base price when publishing

### DIFF
--- a/MSStore.API/Packaged/Models/PriceIds.cs
+++ b/MSStore.API/Packaged/Models/PriceIds.cs
@@ -38,9 +38,15 @@ namespace MSStore.API.Packaged.Models
         /// Whether a price id read from a submission can be sent back unchanged on update.
         /// </summary>
         /// <remarks>
-        /// Everything except <see cref="Base"/> (and a missing value) round-trips. Note that
-        /// an empty price id must never be sent: the API answers <c>200 OK</c> and silently
-        /// resets the product to free, which is how paid apps lost their price.
+        /// Everything except <see cref="Base"/> (and a missing value) round-trips.
+        /// <para>
+        /// An empty price id must never be sent. Update is a full replace with no patch
+        /// semantics, so anything the request does not state explicitly is reset to its default,
+        /// and the default is free. Verified against the API: a <c>null</c> price id, a pricing
+        /// object with the property removed, and an empty pricing object all answer
+        /// <c>200 OK</c> and silently turn the product free. Omitting the property is therefore
+        /// not a way to leave the price untouched - there is no such way.
+        /// </para>
         /// </remarks>
         /// <param name="priceId">The price id to check.</param>
         /// <returns><c>true</c> when <paramref name="priceId"/> is safe to send back.</returns>

--- a/MSStore.API/Packaged/Models/PriceIds.cs
+++ b/MSStore.API/Packaged/Models/PriceIds.cs
@@ -52,7 +52,7 @@ namespace MSStore.API.Packaged.Models
         /// <returns><c>true</c> when <paramref name="priceId"/> is safe to send back.</returns>
         public static bool IsRoundTrippable(string? priceId) =>
             !string.IsNullOrWhiteSpace(priceId) &&
-            !string.Equals(priceId, Base, StringComparison.OrdinalIgnoreCase);
+            !string.Equals(priceId.Trim(), Base, StringComparison.OrdinalIgnoreCase);
 
         /// <summary>
         /// Validates a user supplied price id and converts it to the casing the API expects.

--- a/MSStore.API/Packaged/Models/PriceIds.cs
+++ b/MSStore.API/Packaged/Models/PriceIds.cs
@@ -1,0 +1,103 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Globalization;
+
+namespace MSStore.API.Packaged.Models
+{
+    /// <summary>
+    /// Well-known values for <see cref="Pricing.PriceId"/>, and the rules for which
+    /// of them may be sent back to the Store submission API on an update.
+    /// </summary>
+    /// <remarks>
+    /// These live outside <see cref="Pricing"/> on purpose. That type is serialized with
+    /// <see cref="System.Text.Json.Serialization.JsonIgnoreCondition.Never"/>, so any member
+    /// added to it would show up in the request body.
+    /// </remarks>
+    public static class PriceIds
+    {
+        /// <summary>
+        /// Sentinel meaning "the price tier is not set; use the base price for the app".
+        /// It is a legal value inside <see cref="Pricing.MarketSpecificPricings"/>, but the
+        /// API also returns it as the <em>base</em> price of products managed by the newer
+        /// per-market pricing model - where it cannot be sent back. Updating a submission
+        /// with it fails with <c>'Base' is not a valid PriceId for base price.</c>
+        /// </summary>
+        public const string Base = "Base";
+
+        /// <summary>The app is free.</summary>
+        public const string Free = "Free";
+
+        /// <summary>The app is not available in the given market.</summary>
+        public const string NotAvailable = "NotAvailable";
+
+        private const string TierPrefix = "Tier";
+
+        /// <summary>
+        /// Whether a price id read from a submission can be sent back unchanged on update.
+        /// </summary>
+        /// <remarks>
+        /// Everything except <see cref="Base"/> (and a missing value) round-trips. Note that
+        /// an empty price id must never be sent: the API answers <c>200 OK</c> and silently
+        /// resets the product to free, which is how paid apps lost their price.
+        /// </remarks>
+        /// <param name="priceId">The price id to check.</param>
+        /// <returns><c>true</c> when <paramref name="priceId"/> is safe to send back.</returns>
+        public static bool IsRoundTrippable(string? priceId) =>
+            !string.IsNullOrWhiteSpace(priceId) &&
+            !string.Equals(priceId, Base, StringComparison.OrdinalIgnoreCase);
+
+        /// <summary>
+        /// Validates a user supplied price id and converts it to the casing the API expects.
+        /// </summary>
+        /// <remarks>
+        /// Tier numbers are deliberately not range checked. The documented ranges
+        /// (<c>Tier2</c>-<c>Tier96</c> and <c>Tier1012</c>-<c>Tier1424</c>) describe what a
+        /// dashboard offers, not what the API accepts, and <c>isAdvancedPricingModel</c> is
+        /// not a reliable way to tell the two apart - the API reports it inconsistently for
+        /// the same product. Let the service reject an out of range tier.
+        /// </remarks>
+        /// <param name="priceId">The price id to normalize.</param>
+        /// <param name="normalized">The normalized price id, when valid.</param>
+        /// <returns><c>true</c> when <paramref name="priceId"/> is a value the API accepts.</returns>
+        public static bool TryNormalize(string? priceId, out string? normalized)
+        {
+            normalized = null;
+
+            if (string.IsNullOrWhiteSpace(priceId))
+            {
+                return false;
+            }
+
+            var trimmed = priceId.Trim();
+
+            if (string.Equals(trimmed, Free, StringComparison.OrdinalIgnoreCase))
+            {
+                normalized = Free;
+                return true;
+            }
+
+            if (string.Equals(trimmed, NotAvailable, StringComparison.OrdinalIgnoreCase))
+            {
+                normalized = NotAvailable;
+                return true;
+            }
+
+            if (!trimmed.StartsWith(TierPrefix, StringComparison.OrdinalIgnoreCase))
+            {
+                return false;
+            }
+
+            var tier = trimmed[TierPrefix.Length..];
+
+            if (tier.Length == 0 || !int.TryParse(tier, NumberStyles.None, CultureInfo.InvariantCulture, out var tierNumber))
+            {
+                return false;
+            }
+
+            normalized = string.Concat(TierPrefix, tierNumber.ToString(CultureInfo.InvariantCulture));
+            return true;
+        }
+    }
+}

--- a/MSStore.CLI.UnitTests/BaseCommandLineTest.cs
+++ b/MSStore.CLI.UnitTests/BaseCommandLineTest.cs
@@ -127,6 +127,16 @@ namespace MSStore.CLI.UnitTests
             }
         }
 
+        /// <summary>
+        /// Collapses the line breaks Spectre.Console introduces when it wraps output to the
+        /// console width, so an assertion on message text does not depend on how wide the test
+        /// console happens to be. Local and CI runners wrap at different widths.
+        /// </summary>
+        /// <param name="text">The captured console output.</param>
+        /// <returns>The same text with every run of whitespace collapsed to a single space.</returns>
+        protected static string Unwrapped(string text) =>
+            System.Text.RegularExpressions.Regex.Replace(text, @"\s+", " ");
+
         private readonly List<string> _temporaryPayloadFiles = [];
 
         /// <summary>

--- a/MSStore.CLI.UnitTests/BaseCommandLineTest.cs
+++ b/MSStore.CLI.UnitTests/BaseCommandLineTest.cs
@@ -410,13 +410,14 @@ namespace MSStore.CLI.UnitTests
                 });
         }
 
-        protected void AddDefaultFakeSubmission(string listingDescription = "BaseListingDescription")
+        protected void AddDefaultFakeSubmission(string listingDescription = "BaseListingDescription", Pricing? pricing = null)
         {
             var fakeSubmission = new DevCenterSubmission
             {
                 Id = "123456789",
                 ApplicationCategory = DevCenterApplicationCategory.NotSet,
                 FileUploadUrl = "https://azureblob.com/fileupload",
+                Pricing = pricing,
                 ApplicationPackages =
                     [
                         new ApplicationPackage
@@ -573,9 +574,9 @@ namespace MSStore.CLI.UnitTests
                 });
         }
 
-        protected void AddDefaultFakeSuccessfulSubmission()
+        protected void AddDefaultFakeSuccessfulSubmission(Pricing? pricing = null)
         {
-            AddDefaultFakeSubmission();
+            AddDefaultFakeSubmission(pricing: pricing);
             InitDefaultSubmissionStatusResponseQueue();
 
             FakeStorePackagedAPI

--- a/MSStore.CLI.UnitTests/BaseCommandLineTest.cs
+++ b/MSStore.CLI.UnitTests/BaseCommandLineTest.cs
@@ -128,14 +128,19 @@ namespace MSStore.CLI.UnitTests
         }
 
         /// <summary>
-        /// Collapses the line breaks Spectre.Console introduces when it wraps output to the
-        /// console width, so an assertion on message text does not depend on how wide the test
-        /// console happens to be. Local and CI runners wrap at different widths.
+        /// Reduces captured console output to plain text: strips the ANSI escape sequences
+        /// Spectre.Console emits for styling, and collapses the line breaks it inserts when
+        /// wrapping to the console width. Without this, an assertion on message text depends on
+        /// both the width and the colour support of whatever terminal the test ran under, which
+        /// differs between local runs and CI.
         /// </summary>
         /// <param name="text">The captured console output.</param>
-        /// <returns>The same text with every run of whitespace collapsed to a single space.</returns>
-        protected static string Unwrapped(string text) =>
-            System.Text.RegularExpressions.Regex.Replace(text, @"\s+", " ");
+        /// <returns>The text without styling, with every run of whitespace collapsed to one space.</returns>
+        protected static string PlainConsoleText(string text)
+        {
+            var withoutAnsi = System.Text.RegularExpressions.Regex.Replace(text, @"\x1B\[[0-9;]*[a-zA-Z]", string.Empty);
+            return System.Text.RegularExpressions.Regex.Replace(withoutAnsi, @"\s+", " ");
+        }
 
         private readonly List<string> _temporaryPayloadFiles = [];
 

--- a/MSStore.CLI.UnitTests/BaseCommandLineTest.cs
+++ b/MSStore.CLI.UnitTests/BaseCommandLineTest.cs
@@ -410,14 +410,17 @@ namespace MSStore.CLI.UnitTests
                 });
         }
 
-        protected void AddDefaultFakeSubmission(string listingDescription = "BaseListingDescription", Pricing? pricing = null)
+        protected void AddDefaultFakeSubmission(string listingDescription = "BaseListingDescription", Pricing? pricing = null, bool withoutPricing = false)
         {
             var fakeSubmission = new DevCenterSubmission
             {
                 Id = "123456789",
                 ApplicationCategory = DevCenterApplicationCategory.NotSet,
                 FileUploadUrl = "https://azureblob.com/fileupload",
-                Pricing = pricing,
+
+                // Every real app submission comes back carrying a pricing object, so that is what
+                // the fixtures model. 'withoutPricing' exists only to cover the degenerate case.
+                Pricing = withoutPricing ? null : pricing ?? new Pricing { PriceId = PriceIds.Free },
                 ApplicationPackages =
                     [
                         new ApplicationPackage
@@ -574,9 +577,9 @@ namespace MSStore.CLI.UnitTests
                 });
         }
 
-        protected void AddDefaultFakeSuccessfulSubmission(Pricing? pricing = null)
+        protected void AddDefaultFakeSuccessfulSubmission(Pricing? pricing = null, bool withoutPricing = false)
         {
-            AddDefaultFakeSubmission(pricing: pricing);
+            AddDefaultFakeSubmission(pricing: pricing, withoutPricing: withoutPricing);
             InitDefaultSubmissionStatusResponseQueue();
 
             FakeStorePackagedAPI

--- a/MSStore.CLI.UnitTests/PublishCommandPricingUnitTests.cs
+++ b/MSStore.CLI.UnitTests/PublishCommandPricingUnitTests.cs
@@ -37,12 +37,13 @@ namespace MSStore.CLI.UnitTests
         private async Task<((string Output, string Error) Result, DevCenterSubmission? Sent)> PublishMsixAsync(
             Pricing? pricing,
             int? expectedExitCode = 0,
+            bool withoutPricing = false,
             params string[] extraArgs)
         {
             var path = CopyFilesRecursively("MSIXProject");
             var msixPath = Path.Combine(path, "test.msix");
 
-            AddDefaultFakeSuccessfulSubmission(pricing);
+            AddDefaultFakeSuccessfulSubmission(pricing, withoutPricing);
 
             DevCenterSubmission? sent = null;
             FakeStorePackagedAPI
@@ -135,6 +136,7 @@ namespace MSStore.CLI.UnitTests
             var (result, sent) = await PublishMsixAsync(
                 new Pricing { PriceId = "Base" },
                 0,
+                false,
                 "--priceId",
                 "Tier1012");
 
@@ -148,6 +150,7 @@ namespace MSStore.CLI.UnitTests
             var (_, sent) = await PublishMsixAsync(
                 new Pricing { PriceId = "Tier1012" },
                 0,
+                false,
                 "--priceId",
                 "Tier1424");
 
@@ -155,12 +158,18 @@ namespace MSStore.CLI.UnitTests
         }
 
         [TestMethod]
-        public async Task PublishShouldSucceedWhenTheProductHasNoPricingAtAll()
+        public async Task PublishShouldStopWhenTheProductHasNoPricingAtAll()
         {
-            var (result, sent) = await PublishMsixAsync(null);
+            // Missing pricing is just as unsendable as a bad price id: the API answers
+            // "Pricing data was not provided in the request.". Fail fast with guidance instead
+            // of letting UpdateSubmissionAsync surface a raw 400.
+            var (result, sent) = await PublishMsixAsync(null, -1, withoutPricing: true);
 
-            result.Error.Should().Contain("Submission commit success! Here is some data:");
-            sent!.Pricing.Should().BeNull();
+            result.Error.Should().Contain("Could not preserve this product's price");
+            result.Error.Should().Contain("returned no pricing for this product");
+            result.Error.Should().Contain("--priceId");
+
+            sent.Should().BeNull();
         }
 
         [TestMethod]
@@ -168,7 +177,7 @@ namespace MSStore.CLI.UnitTests
         {
             // The API rejects an update that omits pricing, so an explicit price has to be
             // materialized rather than silently dropped.
-            var (result, sent) = await PublishMsixAsync(null, 0, "--priceId", "Tier1012");
+            var (result, sent) = await PublishMsixAsync(null, 0, true, "--priceId", "Tier1012");
 
             result.Error.Should().Contain("Submission commit success! Here is some data:");
             sent!.Pricing.Should().NotBeNull();

--- a/MSStore.CLI.UnitTests/PublishCommandPricingUnitTests.cs
+++ b/MSStore.CLI.UnitTests/PublishCommandPricingUnitTests.cs
@@ -72,7 +72,7 @@ namespace MSStore.CLI.UnitTests
             // The core regression for issue #112: publishing must never alter the base price.
             var (result, sent) = await PublishMsixAsync(new Pricing { PriceId = priceId });
 
-            result.Error.Should().Contain("Submission commit success! Here is some data:");
+            Unwrapped(result.Error).Should().Contain("Submission commit success! Here is some data:");
 
             sent.Should().NotBeNull();
             sent!.Pricing.Should().NotBeNull();
@@ -99,7 +99,7 @@ namespace MSStore.CLI.UnitTests
             var (result, sent) = await PublishMsixAsync(
                 new Pricing { PriceId = "Tier1012", IsAdvancedPricingModel = true });
 
-            result.Error.Should().Contain("Submission commit success! Here is some data:");
+            Unwrapped(result.Error).Should().Contain("Submission commit success! Here is some data:");
             sent!.Pricing!.PriceId.Should().Be("Tier1012");
         }
 
@@ -108,8 +108,8 @@ namespace MSStore.CLI.UnitTests
         {
             var (result, sent) = await PublishMsixAsync(new Pricing { PriceId = "Base" }, -1);
 
-            result.Error.Should().Contain("Could not preserve this product's price");
-            result.Error.Should().Contain("--priceId");
+            Unwrapped(result.Error).Should().Contain("Could not preserve this product's price");
+            Unwrapped(result.Error).Should().Contain("--priceId");
 
             // Nothing may be sent, otherwise the product would be reset to free.
             sent.Should().BeNull();
@@ -127,7 +127,7 @@ namespace MSStore.CLI.UnitTests
             // wrong: a product with a real tier publishes fine, as the tests above show.
             var (result, _) = await PublishMsixAsync(new Pricing { PriceId = "Base" }, -1);
 
-            result.Error.Should().NotContain("only for Free products");
+            Unwrapped(result.Error).Should().NotContain("only for Free products");
         }
 
         [TestMethod]
@@ -140,7 +140,7 @@ namespace MSStore.CLI.UnitTests
                 "--priceId",
                 "Tier1012");
 
-            result.Error.Should().Contain("Submission commit success! Here is some data:");
+            Unwrapped(result.Error).Should().Contain("Submission commit success! Here is some data:");
             sent!.Pricing!.PriceId.Should().Be("Tier1012");
         }
 
@@ -165,9 +165,9 @@ namespace MSStore.CLI.UnitTests
             // of letting UpdateSubmissionAsync surface a raw 400.
             var (result, sent) = await PublishMsixAsync(null, -1, withoutPricing: true);
 
-            result.Error.Should().Contain("Could not preserve this product's price");
-            result.Error.Should().Contain("returned no pricing for this product");
-            result.Error.Should().Contain("--priceId");
+            Unwrapped(result.Error).Should().Contain("Could not preserve this product's price");
+            Unwrapped(result.Error).Should().Contain("returned no pricing for this product");
+            Unwrapped(result.Error).Should().Contain("--priceId");
 
             sent.Should().BeNull();
         }
@@ -179,7 +179,7 @@ namespace MSStore.CLI.UnitTests
             // materialized rather than silently dropped.
             var (result, sent) = await PublishMsixAsync(null, 0, true, "--priceId", "Tier1012");
 
-            result.Error.Should().Contain("Submission commit success! Here is some data:");
+            Unwrapped(result.Error).Should().Contain("Submission commit success! Here is some data:");
             sent!.Pricing.Should().NotBeNull();
             sent.Pricing!.PriceId.Should().Be("Tier1012");
         }

--- a/MSStore.CLI.UnitTests/PublishCommandPricingUnitTests.cs
+++ b/MSStore.CLI.UnitTests/PublishCommandPricingUnitTests.cs
@@ -72,7 +72,7 @@ namespace MSStore.CLI.UnitTests
             // The core regression for issue #112: publishing must never alter the base price.
             var (result, sent) = await PublishMsixAsync(new Pricing { PriceId = priceId });
 
-            Unwrapped(result.Error).Should().Contain("Submission commit success! Here is some data:");
+            PlainConsoleText(result.Error).Should().Contain("Submission commit success! Here is some data:");
 
             sent.Should().NotBeNull();
             sent!.Pricing.Should().NotBeNull();
@@ -99,7 +99,7 @@ namespace MSStore.CLI.UnitTests
             var (result, sent) = await PublishMsixAsync(
                 new Pricing { PriceId = "Tier1012", IsAdvancedPricingModel = true });
 
-            Unwrapped(result.Error).Should().Contain("Submission commit success! Here is some data:");
+            PlainConsoleText(result.Error).Should().Contain("Submission commit success! Here is some data:");
             sent!.Pricing!.PriceId.Should().Be("Tier1012");
         }
 
@@ -108,8 +108,8 @@ namespace MSStore.CLI.UnitTests
         {
             var (result, sent) = await PublishMsixAsync(new Pricing { PriceId = "Base" }, -1);
 
-            Unwrapped(result.Error).Should().Contain("Could not preserve this product's price");
-            Unwrapped(result.Error).Should().Contain("--priceId");
+            PlainConsoleText(result.Error).Should().Contain("Could not preserve this product's price");
+            PlainConsoleText(result.Error).Should().Contain("--priceId");
 
             // Nothing may be sent, otherwise the product would be reset to free.
             sent.Should().BeNull();
@@ -127,7 +127,7 @@ namespace MSStore.CLI.UnitTests
             // wrong: a product with a real tier publishes fine, as the tests above show.
             var (result, _) = await PublishMsixAsync(new Pricing { PriceId = "Base" }, -1);
 
-            Unwrapped(result.Error).Should().NotContain("only for Free products");
+            PlainConsoleText(result.Error).Should().NotContain("only for Free products");
         }
 
         [TestMethod]
@@ -140,7 +140,7 @@ namespace MSStore.CLI.UnitTests
                 "--priceId",
                 "Tier1012");
 
-            Unwrapped(result.Error).Should().Contain("Submission commit success! Here is some data:");
+            PlainConsoleText(result.Error).Should().Contain("Submission commit success! Here is some data:");
             sent!.Pricing!.PriceId.Should().Be("Tier1012");
         }
 
@@ -165,9 +165,9 @@ namespace MSStore.CLI.UnitTests
             // of letting UpdateSubmissionAsync surface a raw 400.
             var (result, sent) = await PublishMsixAsync(null, -1, withoutPricing: true);
 
-            Unwrapped(result.Error).Should().Contain("Could not preserve this product's price");
-            Unwrapped(result.Error).Should().Contain("returned no pricing for this product");
-            Unwrapped(result.Error).Should().Contain("--priceId");
+            PlainConsoleText(result.Error).Should().Contain("Could not preserve this product's price");
+            PlainConsoleText(result.Error).Should().Contain("returned no pricing for this product");
+            PlainConsoleText(result.Error).Should().Contain("--priceId");
 
             sent.Should().BeNull();
         }
@@ -179,7 +179,7 @@ namespace MSStore.CLI.UnitTests
             // materialized rather than silently dropped.
             var (result, sent) = await PublishMsixAsync(null, 0, true, "--priceId", "Tier1012");
 
-            Unwrapped(result.Error).Should().Contain("Submission commit success! Here is some data:");
+            PlainConsoleText(result.Error).Should().Contain("Submission commit success! Here is some data:");
             sent!.Pricing.Should().NotBeNull();
             sent.Pricing!.PriceId.Should().Be("Tier1012");
         }
@@ -233,6 +233,23 @@ namespace MSStore.CLI.UnitTests
             // Whitespace must not smuggle the Base sentinel past the guard: TryNormalize already
             // treats surrounding whitespace as insignificant, and sending "Base " is still a 400.
             PriceIds.IsRoundTrippable(priceId).Should().BeFalse();
+        }
+
+        [TestMethod]
+        public void PlainConsoleTextShouldStripStylingAndWrapping()
+        {
+            // Reproduces what CI actually captured. Spectre emitted bold escapes around "Free"
+            // and wrapped the sentence, so a verbatim assertion passed locally (no colour) and
+            // failed on every CI runner. Asserting through PlainConsoleText removes both.
+            var captured =
+                "The submission API would accept that and silently reset the product to \u001b[1mFree\u001b[0m,\n"
+                + "so the update has been\nstopped instead.";
+
+            PlainConsoleText(captured)
+                .Should()
+                .Contain("silently reset the product to Free")
+                .And
+                .Contain("so the update has been stopped instead.");
         }
 
         private static ParseResult ParsePublish(params string[] args) =>

--- a/MSStore.CLI.UnitTests/PublishCommandPricingUnitTests.cs
+++ b/MSStore.CLI.UnitTests/PublishCommandPricingUnitTests.cs
@@ -1,0 +1,225 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.CommandLine;
+using MSStore.API.Packaged.Models;
+using MSStore.CLI.Commands;
+
+namespace MSStore.CLI.UnitTests
+{
+    /// <summary>
+    /// Guards the base price across a publish.
+    /// </summary>
+    /// <remarks>
+    /// Verified against the live submission API. On update, the base price behaves like this:
+    /// <list type="bullet">
+    /// <item><description><c>Free</c>/<c>Tier96</c>/<c>Tier1012</c>/<c>Tier1424</c> - <c>200 OK</c>, value preserved.</description></item>
+    /// <item><description><c>Base</c> - <c>400</c> <c>'Base' is not a valid PriceId for base price.</c></description></item>
+    /// <item><description>empty - <c>200 OK</c>, and the product silently becomes free. This is issue #112.</description></item>
+    /// <item><description><c>pricing</c> omitted - <c>400</c> <c>Pricing data was not provided in the request.</c></description></item>
+    /// </list>
+    /// </remarks>
+    [TestClass]
+    public class PublishCommandPricingUnitTests : BaseCommandLineTest
+    {
+        public TestContext TestContext { get; set; } = null!;
+
+        [TestInitialize]
+        public void Init()
+        {
+            FakeLogin();
+            AddDefaultFakeAccount();
+            AddFakeApps();
+        }
+
+        private async Task<((string Output, string Error) Result, DevCenterSubmission? Sent)> PublishMsixAsync(
+            Pricing? pricing,
+            int? expectedExitCode = 0,
+            params string[] extraArgs)
+        {
+            var path = CopyFilesRecursively("MSIXProject");
+            var msixPath = Path.Combine(path, "test.msix");
+
+            AddDefaultFakeSuccessfulSubmission(pricing);
+
+            DevCenterSubmission? sent = null;
+            FakeStorePackagedAPI
+                .Setup(x => x.UpdateSubmissionAsync(
+                    It.IsAny<string>(),
+                    It.IsAny<string>(),
+                    It.IsAny<DevCenterSubmission>(),
+                    It.IsAny<CancellationToken>()))
+                .Callback<string, string, DevCenterSubmission, CancellationToken>((_, _, s, _) => sent = s)
+                .ReturnsAsync((string _, string _, DevCenterSubmission s, CancellationToken _) => s);
+
+            string[] args = ["publish", msixPath, "--appId", FakeApps[0].Id!, "--verbose", .. extraArgs];
+
+            var result = await ParseAndInvokeAsync(args, expectedExitCode);
+
+            return (result, sent);
+        }
+
+        [TestMethod]
+        [DataRow("Tier1012")]
+        [DataRow("Tier1424")]
+        [DataRow("Tier96")]
+        [DataRow("Free")]
+        public async Task PublishShouldSendThePriceBackUnchanged(string priceId)
+        {
+            // The core regression for issue #112: publishing must never alter the base price.
+            var (result, sent) = await PublishMsixAsync(new Pricing { PriceId = priceId });
+
+            result.Error.Should().Contain("Submission commit success! Here is some data:");
+
+            sent.Should().NotBeNull();
+            sent!.Pricing.Should().NotBeNull();
+            sent.Pricing!.PriceId.Should().Be(priceId);
+        }
+
+        [TestMethod]
+        public async Task PublishShouldNeverSendAnEmptyPrice()
+        {
+            // Commit 0b4b0bc set PriceId to null here. The API answers 200 OK and resets the
+            // product to free, so this can only be caught by inspecting the outgoing payload.
+            var (_, sent) = await PublishMsixAsync(
+                new Pricing { PriceId = "Tier1012", IsAdvancedPricingModel = true });
+
+            sent!.Pricing!.PriceId.Should().NotBeNullOrWhiteSpace();
+            sent.Pricing.PriceId.Should().Be("Tier1012");
+        }
+
+        [TestMethod]
+        public async Task PublishShouldIgnoreIsAdvancedPricingModel()
+        {
+            // isAdvancedPricingModel only describes which tier range a dashboard offers, and the
+            // API reports it inconsistently for the same product. It must not drive any decision.
+            var (result, sent) = await PublishMsixAsync(
+                new Pricing { PriceId = "Tier1012", IsAdvancedPricingModel = true });
+
+            result.Error.Should().Contain("Submission commit success! Here is some data:");
+            sent!.Pricing!.PriceId.Should().Be("Tier1012");
+        }
+
+        [TestMethod]
+        public async Task PublishShouldStopWhenThePriceCannotBePreserved()
+        {
+            var (result, sent) = await PublishMsixAsync(new Pricing { PriceId = "Base" }, -1);
+
+            result.Error.Should().Contain("Could not preserve this product's price");
+            result.Error.Should().Contain("--priceId");
+
+            // Nothing may be sent, otherwise the product would be reset to free.
+            sent.Should().BeNull();
+
+            FakeStorePackagedAPI
+                .Verify(
+                    x => x.DeleteSubmissionAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
+                    Times.Once);
+        }
+
+        [TestMethod]
+        public async Task PublishShouldNotClaimOnlyFreeProductsAreSupported()
+        {
+            // The old message said "App updates are supported only for Free products", which is
+            // wrong: a product with a real tier publishes fine, as the tests above show.
+            var (result, _) = await PublishMsixAsync(new Pricing { PriceId = "Base" }, -1);
+
+            result.Error.Should().NotContain("only for Free products");
+        }
+
+        [TestMethod]
+        public async Task PublishWithPriceIdShouldRecoverAProductWhoseBasePriceIsNotRoundTrippable()
+        {
+            var (result, sent) = await PublishMsixAsync(
+                new Pricing { PriceId = "Base" },
+                0,
+                "--priceId",
+                "Tier1012");
+
+            result.Error.Should().Contain("Submission commit success! Here is some data:");
+            sent!.Pricing!.PriceId.Should().Be("Tier1012");
+        }
+
+        [TestMethod]
+        public async Task PublishWithPriceIdShouldOverrideAnExistingTier()
+        {
+            var (_, sent) = await PublishMsixAsync(
+                new Pricing { PriceId = "Tier1012" },
+                0,
+                "--priceId",
+                "Tier1424");
+
+            sent!.Pricing!.PriceId.Should().Be("Tier1424");
+        }
+
+        [TestMethod]
+        public async Task PublishShouldSucceedWhenTheProductHasNoPricingAtAll()
+        {
+            var (result, sent) = await PublishMsixAsync(null);
+
+            result.Error.Should().Contain("Submission commit success! Here is some data:");
+            sent!.Pricing.Should().BeNull();
+        }
+
+        [TestMethod]
+        public async Task PublishWithPriceIdShouldApplyEvenWhenTheProductHasNoPricingAtAll()
+        {
+            // The API rejects an update that omits pricing, so an explicit price has to be
+            // materialized rather than silently dropped.
+            var (result, sent) = await PublishMsixAsync(null, 0, "--priceId", "Tier1012");
+
+            result.Error.Should().Contain("Submission commit success! Here is some data:");
+            sent!.Pricing.Should().NotBeNull();
+            sent.Pricing!.PriceId.Should().Be("Tier1012");
+        }
+
+        private static ParseResult ParsePublish(params string[] args) =>
+            new PublishCommand().Parse(args);
+
+        [TestMethod]
+        public void PublishCommandPriceIdShouldDefaultToNullWhenOmitted()
+        {
+            ParsePublish("publish", ".")
+                .GetValue(PublishCommand.PriceIdOption)
+                .Should()
+                .BeNull();
+        }
+
+        [TestMethod]
+        [DataRow("Tier1012", "Tier1012")]
+        [DataRow("tier1012", "Tier1012")]
+        [DataRow("TIER1012", "Tier1012")]
+        [DataRow(" Tier1012 ", "Tier1012")]
+        [DataRow("Free", "Free")]
+        [DataRow("free", "Free")]
+        [DataRow("NotAvailable", "NotAvailable")]
+        [DataRow("Tier2", "Tier2")]
+        public void PublishCommandPriceIdShouldNormalizeAcceptedValues(string input, string expected)
+        {
+            var parseResult = ParsePublish("publish", ".", "--priceId", input);
+
+            parseResult.Errors.Should().BeEmpty();
+            parseResult.GetValue(PublishCommand.PriceIdOption).Should().Be(expected);
+        }
+
+        [TestMethod]
+        [DataRow("Base")]
+        [DataRow("Tier")]
+        [DataRow("1012")]
+        [DataRow("TierAbc")]
+        [DataRow("Tier-1")]
+        [DataRow("not-a-tier")]
+        public void PublishCommandPriceIdShouldRejectValuesTheApiWouldNotAccept(string input)
+        {
+            // "Base" is rejected on purpose: it is exactly the value that cannot be sent back.
+            ParsePublish("publish", ".", "--priceId", input)
+                .Errors
+                .Should()
+                .ContainSingle()
+                .Which
+                .Message
+                .Should()
+                .Be("Invalid price id. The value must be 'Free', 'NotAvailable', or a tier such as 'Tier1012'.");
+        }
+    }
+}

--- a/MSStore.CLI.UnitTests/PublishCommandPricingUnitTests.cs
+++ b/MSStore.CLI.UnitTests/PublishCommandPricingUnitTests.cs
@@ -208,6 +208,33 @@ namespace MSStore.CLI.UnitTests
             json.Should().Contain("\"PriceId\":\"Tier1012\"");
         }
 
+        [TestMethod]
+        [DataRow("Tier1012")]
+        [DataRow("Free")]
+        [DataRow("NotAvailable")]
+        [DataRow("Tier2")]
+        public void RoundTrippablePriceIdsAreSentBackUnchanged(string priceId)
+        {
+            PriceIds.IsRoundTrippable(priceId).Should().BeTrue();
+        }
+
+        [TestMethod]
+        [DataRow(null)]
+        [DataRow("")]
+        [DataRow("   ")]
+        [DataRow("Base")]
+        [DataRow("base")]
+        [DataRow("BASE")]
+        [DataRow("Base ")]
+        [DataRow(" Base")]
+        [DataRow("  base  ")]
+        public void UnsendablePriceIdsAreNotRoundTrippable(string? priceId)
+        {
+            // Whitespace must not smuggle the Base sentinel past the guard: TryNormalize already
+            // treats surrounding whitespace as insignificant, and sending "Base " is still a 400.
+            PriceIds.IsRoundTrippable(priceId).Should().BeFalse();
+        }
+
         private static ParseResult ParsePublish(params string[] args) =>
             new PublishCommand().Parse(args);
 

--- a/MSStore.CLI.UnitTests/PublishCommandPricingUnitTests.cs
+++ b/MSStore.CLI.UnitTests/PublishCommandPricingUnitTests.cs
@@ -2,6 +2,8 @@
 // Licensed under the MIT License.
 
 using System.CommandLine;
+using System.Text.Json;
+using MSStore.API.Models;
 using MSStore.API.Packaged.Models;
 using MSStore.CLI.Commands;
 
@@ -171,6 +173,30 @@ namespace MSStore.CLI.UnitTests
             result.Error.Should().Contain("Submission commit success! Here is some data:");
             sent!.Pricing.Should().NotBeNull();
             sent.Pricing!.PriceId.Should().Be("Tier1012");
+        }
+
+        [TestMethod]
+        public void PricingMustAlwaysSerializeThePriceIdProperty()
+        {
+            // Guards against "tidying" the payload by omitting a null PriceId. Update has no
+            // patch semantics: a pricing object with the property removed is accepted with
+            // 200 OK and turns the product free, exactly like sending it as null. Adding
+            // JsonIgnore(WhenWritingNull) to Pricing.PriceId would silently reintroduce #112.
+            var json = JsonSerializer.Serialize(
+                new DevCenterSubmission { Pricing = new Pricing { PriceId = null } },
+                SourceGenerationContext.GetCustom().DevCenterSubmission);
+
+            json.Should().Contain("\"PriceId\"");
+        }
+
+        [TestMethod]
+        public void PricingShouldSerializeARealTierVerbatim()
+        {
+            var json = JsonSerializer.Serialize(
+                new DevCenterSubmission { Pricing = new Pricing { PriceId = "Tier1012" } },
+                SourceGenerationContext.GetCustom().DevCenterSubmission);
+
+            json.Should().Contain("\"PriceId\":\"Tier1012\"");
         }
 
         private static ParseResult ParsePublish(params string[] args) =>

--- a/MSStore.CLI.UnitTests/SubmissionCommandPackagedUnitTests.cs
+++ b/MSStore.CLI.UnitTests/SubmissionCommandPackagedUnitTests.cs
@@ -145,6 +145,100 @@ namespace MSStore.CLI.UnitTests
         }
 
         [TestMethod]
+        public async Task PackagedSubmissionUpdateCommandShouldAcceptAPayloadCarryingARealTier()
+        {
+            // A per-market priced product can only be updated by naming a real tier in the
+            // payload. Blocking on the *current* submission's price would reject this.
+            FakeApps[0].PendingApplicationSubmission = new ApplicationSubmissionInfo
+            {
+                Id = "123456789"
+            };
+
+            AddDefaultFakeSubmission(pricing: new Pricing { PriceId = "Base" });
+
+            DevCenterSubmission? sent = null;
+            FakeStorePackagedAPI
+                .Setup(x => x.UpdateSubmissionAsync(
+                    It.IsAny<string>(),
+                    It.IsAny<string>(),
+                    It.IsAny<DevCenterSubmission>(),
+                    It.IsAny<CancellationToken>()))
+                .Callback<string, string, DevCenterSubmission, CancellationToken>((_, _, s, _) => sent = s)
+                .ReturnsAsync((string _, string _, DevCenterSubmission s, CancellationToken _) => s);
+
+            var result = await ParseAndInvokeAsync(
+                [
+                    "submission",
+                    "update",
+                    FakeApps[0].Id!,
+                    @"
+{
+""Pricing"": { ""PriceId"": ""Tier1012"" },
+""ApplicationPackages"":
+    [
+        {
+            ""FileName"":""C:\\temp\\installer.msix""
+        }
+    ]
+}"
+                ]);
+
+            result.Error.Should().Contain("Updating submission product");
+            sent!.Pricing!.PriceId.Should().Be("Tier1012");
+        }
+
+        [TestMethod]
+        public async Task PackagedSubmissionUpdateCommandShouldRejectAPayloadThatWouldResetThePrice()
+        {
+            // "Base" is what the API hands back for a per-market priced product, and sending it
+            // straight back is rejected with "'Base' is not a valid PriceId for base price."
+            var result = await ParseAndInvokeAsync(
+                [
+                    "submission",
+                    "update",
+                    FakeApps[0].Id!,
+                    @"{ ""Pricing"": { ""PriceId"": ""Base"" } }"
+                ], -1);
+
+            result.Error.Should().Contain("which the submission API will not accept");
+            result.Error.Should().NotContain("only for Free products");
+
+            FakeStorePackagedAPI
+                .Verify(
+                    x => x.UpdateSubmissionAsync(
+                        It.IsAny<string>(),
+                        It.IsAny<string>(),
+                        It.IsAny<DevCenterSubmission>(),
+                        It.IsAny<CancellationToken>()),
+                    Times.Never);
+        }
+
+        [TestMethod]
+        public async Task PackagedSubmissionUpdateCommandShouldRejectAPayloadWithAnEmptyPrice()
+        {
+            // An empty price is the dangerous one: the API answers 200 OK and silently resets
+            // the product to free.
+            var result = await ParseAndInvokeAsync(
+                [
+                    "submission",
+                    "update",
+                    FakeApps[0].Id!,
+                    @"{ ""Pricing"": { ""TrialPeriod"": ""NoFreeTrial"" } }"
+                ], -1);
+
+            result.Error.Should().Contain("which the submission API will not accept");
+
+            FakeStorePackagedAPI
+                .Verify(
+                    x => x.UpdateSubmissionAsync(
+                        It.IsAny<string>(),
+                        It.IsAny<string>(),
+                        It.IsAny<DevCenterSubmission>(),
+                        It.IsAny<CancellationToken>()),
+                    Times.Never);
+        }
+
+        [TestMethod]
         public async Task PackagedSubmissionUpdateCommandWithPayloadOption()
         {
             var payloadFilePath = CreateTemporaryPayloadFile(

--- a/MSStore.CLI.UnitTests/SubmissionCommandPackagedUnitTests.cs
+++ b/MSStore.CLI.UnitTests/SubmissionCommandPackagedUnitTests.cs
@@ -46,8 +46,8 @@ namespace MSStore.CLI.UnitTests
                     FakeApps[0].Id!
                 ]);
 
-            Unwrapped(result.Error).Should().Contain("Code1");
-            Unwrapped(result.Error).Should().Contain("Detail1");
+            PlainConsoleText(result.Error).Should().Contain("Code1");
+            PlainConsoleText(result.Error).Should().Contain("Detail1");
         }
 
         [TestMethod]
@@ -141,7 +141,7 @@ namespace MSStore.CLI.UnitTests
 }"
                 ]);
 
-            Unwrapped(result.Error).Should().Contain("Updating submission product");
+            PlainConsoleText(result.Error).Should().Contain("Updating submission product");
             result.Output.Should().Contain("\"FileUploadUrl\": \"https://azureblob.com/fileupload\"");
         }
 
@@ -184,7 +184,7 @@ namespace MSStore.CLI.UnitTests
 }"
                 ]);
 
-            Unwrapped(result.Error).Should().Contain("Updating submission product");
+            PlainConsoleText(result.Error).Should().Contain("Updating submission product");
             sent!.Pricing!.PriceId.Should().Be("Tier1012");
         }
 
@@ -201,9 +201,9 @@ namespace MSStore.CLI.UnitTests
                     @"{ ""Pricing"": { ""PriceId"": ""Base"" } }"
                 ], -1);
 
-            Unwrapped(result.Error).Should().Contain("sets 'Pricing.PriceId' to 'Base'");
-            Unwrapped(result.Error).Should().Contain("which the submission API rejects");
-            Unwrapped(result.Error).Should().NotContain("only for Free products");
+            PlainConsoleText(result.Error).Should().Contain("sets 'Pricing.PriceId' to 'Base'");
+            PlainConsoleText(result.Error).Should().Contain("which the submission API rejects");
+            PlainConsoleText(result.Error).Should().NotContain("only for Free products");
 
             FakeStorePackagedAPI
                 .Verify(
@@ -228,8 +228,8 @@ namespace MSStore.CLI.UnitTests
                     @"{ ""Pricing"": { ""TrialPeriod"": ""NoFreeTrial"" } }"
                 ], -1);
 
-            Unwrapped(result.Error).Should().Contain("does not set 'Pricing.PriceId'");
-            Unwrapped(result.Error).Should().Contain("silently reset the product to Free");
+            PlainConsoleText(result.Error).Should().Contain("does not set 'Pricing.PriceId'");
+            PlainConsoleText(result.Error).Should().Contain("silently reset the product to Free");
 
             FakeStorePackagedAPI
                 .Verify(
@@ -255,7 +255,7 @@ namespace MSStore.CLI.UnitTests
                     @"{ ""ApplicationPackages"": [ { ""FileName"": ""test.msix"" } ] }"
                 ], -1);
 
-            Unwrapped(result.Error).Should().Contain("has no 'Pricing' object");
+            PlainConsoleText(result.Error).Should().Contain("has no 'Pricing' object");
 
             FakeStorePackagedAPI
                 .Verify(
@@ -289,7 +289,7 @@ namespace MSStore.CLI.UnitTests
                     @"{ ""Pricing"": { ""PriceId"": ""Base"" } }"
                 ], -1);
 
-            Unwrapped(result.Error).Should().Contain("which the submission API rejects");
+            PlainConsoleText(result.Error).Should().Contain("which the submission API rejects");
 
             FakeStorePackagedAPI
                 .Verify(
@@ -321,7 +321,7 @@ namespace MSStore.CLI.UnitTests
                     payloadFilePath
                 ]);
 
-            Unwrapped(result.Error).Should().Contain("Updating submission product");
+            PlainConsoleText(result.Error).Should().Contain("Updating submission product");
             result.Output.Should().Contain("\"FileUploadUrl\": \"https://azureblob.com/fileupload\"");
         }
 
@@ -348,7 +348,7 @@ namespace MSStore.CLI.UnitTests
                     payloadFilePath
                 ]);
 
-            Unwrapped(result.Error).Should().Contain("Updating submission product");
+            PlainConsoleText(result.Error).Should().Contain("Updating submission product");
             result.Output.Should().Contain("\"FileUploadUrl\": \"https://azureblob.com/fileupload\"");
         }
 
@@ -377,7 +377,7 @@ namespace MSStore.CLI.UnitTests
                     "-"
                 ]);
 
-            Unwrapped(result.Error).Should().Contain("Updating submission product");
+            PlainConsoleText(result.Error).Should().Contain("Updating submission product");
             result.Output.Should().Contain("\"FileUploadUrl\": \"https://azureblob.com/fileupload\"");
         }
 
@@ -408,7 +408,7 @@ namespace MSStore.CLI.UnitTests
                     FakeApps[0].Id!
                 ]);
 
-            Unwrapped(result.Error).Should().Contain("Updating submission product");
+            PlainConsoleText(result.Error).Should().Contain("Updating submission product");
             result.Output.Should().Contain("\"FileUploadUrl\": \"https://azureblob.com/fileupload\"");
         }
 
@@ -422,7 +422,7 @@ namespace MSStore.CLI.UnitTests
                     FakeApps[0].Id!
                 ], 1);
 
-            Unwrapped(result.Error).Should().Contain("No 'product' was provided.");
+            PlainConsoleText(result.Error).Should().Contain("No 'product' was provided.");
         }
 
         [TestMethod]
@@ -436,7 +436,7 @@ namespace MSStore.CLI.UnitTests
                     "this-file-does-not-exist.json"
                 ], 1);
 
-            Unwrapped(result.Error).Should().Contain("is neither a JSON payload nor a path to an existing file");
+            PlainConsoleText(result.Error).Should().Contain("is neither a JSON payload nor a path to an existing file");
         }
 
         [TestMethod]
@@ -464,7 +464,7 @@ namespace MSStore.CLI.UnitTests
                     payloadFilePath
                 ], 1);
 
-            Unwrapped(result.Error).Should().Contain("Use only one of them.");
+            PlainConsoleText(result.Error).Should().Contain("Use only one of them.");
         }
 
         [TestMethod]
@@ -507,7 +507,7 @@ namespace MSStore.CLI.UnitTests
                     It.IsAny<CancellationToken>()),
                 Times.Once);
 
-            Unwrapped(result.Error).Should().Contain("Updating submission product");
+            PlainConsoleText(result.Error).Should().Contain("Updating submission product");
             result.Output.Should().Contain("\"FileUploadUrl\": \"https://azureblob.com/fileupload\"");
         }
 
@@ -535,7 +535,7 @@ namespace MSStore.CLI.UnitTests
 }"
                 ]);
 
-            Unwrapped(result.Error).Should().Contain("Updating submission product");
+            PlainConsoleText(result.Error).Should().Contain("Updating submission product");
             result.Output.Should().Contain("\"FileUploadUrl\": \"https://azureblob.com/fileupload\"");
         }
 
@@ -567,7 +567,7 @@ namespace MSStore.CLI.UnitTests
                     payloadFilePath
                 ]);
 
-            Unwrapped(result.Error).Should().Contain("Updating submission product");
+            PlainConsoleText(result.Error).Should().Contain("Updating submission product");
             result.Output.Should().Contain("\"FileUploadUrl\": \"https://azureblob.com/fileupload\"");
         }
 
@@ -593,7 +593,7 @@ namespace MSStore.CLI.UnitTests
                     FakeApps[0].Id!
                 ]);
 
-            Unwrapped(result.Error).Should().Contain("Submission Committed with status");
+            PlainConsoleText(result.Error).Should().Contain("Submission Committed with status");
         }
 
         [TestMethod]
@@ -613,7 +613,7 @@ namespace MSStore.CLI.UnitTests
                     FakeApps[0].Id!
                 ]);
 
-            Unwrapped(result.Error).Should().Contain("Submission commit success!");
+            PlainConsoleText(result.Error).Should().Contain("Submission commit success!");
         }
 
         [TestMethod]
@@ -637,8 +637,8 @@ namespace MSStore.CLI.UnitTests
 
             FakeConsole.Verify(x => x.YesNoConfirmationAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Once);
 
-            Unwrapped(result.Error).Should().Contain($"Found Pending Submission with Id '{FakeApps[0].PendingApplicationSubmission!.Id}'");
-            Unwrapped(result.Error).Should().Contain("Existing submission deleted!");
+            PlainConsoleText(result.Error).Should().Contain($"Found Pending Submission with Id '{FakeApps[0].PendingApplicationSubmission!.Id}'");
+            PlainConsoleText(result.Error).Should().Contain("Existing submission deleted!");
         }
     }
 }

--- a/MSStore.CLI.UnitTests/SubmissionCommandPackagedUnitTests.cs
+++ b/MSStore.CLI.UnitTests/SubmissionCommandPackagedUnitTests.cs
@@ -200,6 +200,7 @@ namespace MSStore.CLI.UnitTests
                     @"{ ""Pricing"": { ""PriceId"": ""Base"" } }"
                 ], -1);
 
+            result.Error.Should().Contain("sets 'Pricing.PriceId' to 'Base'");
             result.Error.Should().Contain("which the submission API will not accept");
             result.Error.Should().NotContain("only for Free products");
 
@@ -226,6 +227,7 @@ namespace MSStore.CLI.UnitTests
                     @"{ ""Pricing"": { ""TrialPeriod"": ""NoFreeTrial"" } }"
                 ], -1);
 
+            result.Error.Should().Contain("does not set 'Pricing.PriceId'");
             result.Error.Should().Contain("which the submission API will not accept");
 
             FakeStorePackagedAPI

--- a/MSStore.CLI.UnitTests/SubmissionCommandPackagedUnitTests.cs
+++ b/MSStore.CLI.UnitTests/SubmissionCommandPackagedUnitTests.cs
@@ -201,7 +201,7 @@ namespace MSStore.CLI.UnitTests
                 ], -1);
 
             result.Error.Should().Contain("sets 'Pricing.PriceId' to 'Base'");
-            result.Error.Should().Contain("which the submission API will not accept");
+            result.Error.Should().Contain("which the submission API rejects");
             result.Error.Should().NotContain("only for Free products");
 
             FakeStorePackagedAPI
@@ -228,7 +228,7 @@ namespace MSStore.CLI.UnitTests
                 ], -1);
 
             result.Error.Should().Contain("does not set 'Pricing.PriceId'");
-            result.Error.Should().Contain("which the submission API will not accept");
+            result.Error.Should().Contain("silently reset the product to Free");
 
             FakeStorePackagedAPI
                 .Verify(

--- a/MSStore.CLI.UnitTests/SubmissionCommandPackagedUnitTests.cs
+++ b/MSStore.CLI.UnitTests/SubmissionCommandPackagedUnitTests.cs
@@ -131,6 +131,7 @@ namespace MSStore.CLI.UnitTests
                     FakeApps[0].Id!,
                     @"
 {
+""Pricing"": { ""PriceId"": ""Free"" },
 ""ApplicationPackages"":
     [
         {
@@ -241,11 +242,68 @@ namespace MSStore.CLI.UnitTests
         }
 
         [TestMethod]
+        public async Task PackagedSubmissionUpdateCommandShouldRejectAPayloadWithNoPricingObject()
+        {
+            // An update replaces the whole submission, so a payload without pricing is rejected
+            // outright ("Pricing data was not provided in the request."). Stopping here also
+            // avoids stranding the draft this command just created.
+            var result = await ParseAndInvokeAsync(
+                [
+                    "submission",
+                    "update",
+                    FakeApps[0].Id!,
+                    @"{ ""ApplicationPackages"": [ { ""FileName"": ""test.msix"" } ] }"
+                ], -1);
+
+            result.Error.Should().Contain("has no 'Pricing' object");
+
+            FakeStorePackagedAPI
+                .Verify(
+                    x => x.UpdateSubmissionAsync(
+                        It.IsAny<string>(),
+                        It.IsAny<string>(),
+                        It.IsAny<DevCenterSubmission>(),
+                        It.IsAny<CancellationToken>()),
+                    Times.Never);
+
+            // The draft was created by this command, so it must not be left behind.
+            FakeStorePackagedAPI
+                .Verify(
+                    x => x.DeleteSubmissionAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
+                    Times.Once);
+        }
+
+        [TestMethod]
+        public async Task PackagedSubmissionUpdateCommandShouldNotDeleteADraftItDidNotCreate()
+        {
+            FakeApps[0].PendingApplicationSubmission = new ApplicationSubmissionInfo
+            {
+                Id = "123456789"
+            };
+
+            var result = await ParseAndInvokeAsync(
+                [
+                    "submission",
+                    "update",
+                    FakeApps[0].Id!,
+                    @"{ ""Pricing"": { ""PriceId"": ""Base"" } }"
+                ], -1);
+
+            result.Error.Should().Contain("which the submission API rejects");
+
+            FakeStorePackagedAPI
+                .Verify(
+                    x => x.DeleteSubmissionAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
+                    Times.Never);
+        }
+
+        [TestMethod]
         public async Task PackagedSubmissionUpdateCommandWithPayloadOption()
         {
             var payloadFilePath = CreateTemporaryPayloadFile(
                 @"
 {
+""Pricing"": { ""PriceId"": ""Free"" },
 ""ApplicationPackages"":
     [
         {
@@ -273,6 +331,7 @@ namespace MSStore.CLI.UnitTests
             var payloadFilePath = CreateTemporaryPayloadFile(
                 @"
 {
+""Pricing"": { ""PriceId"": ""Free"" },
 ""ApplicationPackages"":
     [
         {
@@ -301,6 +360,7 @@ namespace MSStore.CLI.UnitTests
                 .ReturnsAsync(
                     @"
 {
+""Pricing"": { ""PriceId"": ""Free"" },
 ""ApplicationPackages"":
     [
         {
@@ -332,6 +392,7 @@ namespace MSStore.CLI.UnitTests
                 .ReturnsAsync(
                     @"
 {
+""Pricing"": { ""PriceId"": ""Free"" },
 ""ApplicationPackages"":
     [
         {
@@ -384,6 +445,7 @@ namespace MSStore.CLI.UnitTests
             var payloadFilePath = CreateTemporaryPayloadFile(
                 @"
 {
+""Pricing"": { ""PriceId"": ""Free"" },
 ""ApplicationPackages"":
     [
         {
@@ -415,6 +477,7 @@ namespace MSStore.CLI.UnitTests
             var payloadFilePath = CreateTemporaryPayloadFile(
                 @"
 {
+""Pricing"": { ""PriceId"": ""Free"" },
 ""Listings"":
     {
         ""en-us"":
@@ -458,6 +521,7 @@ namespace MSStore.CLI.UnitTests
                     FakeApps[0].Id!,
                     @"
 {
+""Pricing"": { ""PriceId"": ""Free"" },
 ""Listings"":
     {
         ""en-us"":
@@ -481,6 +545,7 @@ namespace MSStore.CLI.UnitTests
             var payloadFilePath = CreateTemporaryPayloadFile(
                 @"
 {
+""Pricing"": { ""PriceId"": ""Free"" },
 ""Listings"":
     {
         ""en-us"":

--- a/MSStore.CLI.UnitTests/SubmissionCommandPackagedUnitTests.cs
+++ b/MSStore.CLI.UnitTests/SubmissionCommandPackagedUnitTests.cs
@@ -46,8 +46,8 @@ namespace MSStore.CLI.UnitTests
                     FakeApps[0].Id!
                 ]);
 
-            result.Error.Should().Contain("Code1");
-            result.Error.Should().Contain("Detail1");
+            Unwrapped(result.Error).Should().Contain("Code1");
+            Unwrapped(result.Error).Should().Contain("Detail1");
         }
 
         [TestMethod]
@@ -141,7 +141,7 @@ namespace MSStore.CLI.UnitTests
 }"
                 ]);
 
-            result.Error.Should().Contain("Updating submission product");
+            Unwrapped(result.Error).Should().Contain("Updating submission product");
             result.Output.Should().Contain("\"FileUploadUrl\": \"https://azureblob.com/fileupload\"");
         }
 
@@ -184,7 +184,7 @@ namespace MSStore.CLI.UnitTests
 }"
                 ]);
 
-            result.Error.Should().Contain("Updating submission product");
+            Unwrapped(result.Error).Should().Contain("Updating submission product");
             sent!.Pricing!.PriceId.Should().Be("Tier1012");
         }
 
@@ -201,9 +201,9 @@ namespace MSStore.CLI.UnitTests
                     @"{ ""Pricing"": { ""PriceId"": ""Base"" } }"
                 ], -1);
 
-            result.Error.Should().Contain("sets 'Pricing.PriceId' to 'Base'");
-            result.Error.Should().Contain("which the submission API rejects");
-            result.Error.Should().NotContain("only for Free products");
+            Unwrapped(result.Error).Should().Contain("sets 'Pricing.PriceId' to 'Base'");
+            Unwrapped(result.Error).Should().Contain("which the submission API rejects");
+            Unwrapped(result.Error).Should().NotContain("only for Free products");
 
             FakeStorePackagedAPI
                 .Verify(
@@ -228,8 +228,8 @@ namespace MSStore.CLI.UnitTests
                     @"{ ""Pricing"": { ""TrialPeriod"": ""NoFreeTrial"" } }"
                 ], -1);
 
-            result.Error.Should().Contain("does not set 'Pricing.PriceId'");
-            result.Error.Should().Contain("silently reset the product to Free");
+            Unwrapped(result.Error).Should().Contain("does not set 'Pricing.PriceId'");
+            Unwrapped(result.Error).Should().Contain("silently reset the product to Free");
 
             FakeStorePackagedAPI
                 .Verify(
@@ -255,7 +255,7 @@ namespace MSStore.CLI.UnitTests
                     @"{ ""ApplicationPackages"": [ { ""FileName"": ""test.msix"" } ] }"
                 ], -1);
 
-            result.Error.Should().Contain("has no 'Pricing' object");
+            Unwrapped(result.Error).Should().Contain("has no 'Pricing' object");
 
             FakeStorePackagedAPI
                 .Verify(
@@ -289,7 +289,7 @@ namespace MSStore.CLI.UnitTests
                     @"{ ""Pricing"": { ""PriceId"": ""Base"" } }"
                 ], -1);
 
-            result.Error.Should().Contain("which the submission API rejects");
+            Unwrapped(result.Error).Should().Contain("which the submission API rejects");
 
             FakeStorePackagedAPI
                 .Verify(
@@ -321,7 +321,7 @@ namespace MSStore.CLI.UnitTests
                     payloadFilePath
                 ]);
 
-            result.Error.Should().Contain("Updating submission product");
+            Unwrapped(result.Error).Should().Contain("Updating submission product");
             result.Output.Should().Contain("\"FileUploadUrl\": \"https://azureblob.com/fileupload\"");
         }
 
@@ -348,7 +348,7 @@ namespace MSStore.CLI.UnitTests
                     payloadFilePath
                 ]);
 
-            result.Error.Should().Contain("Updating submission product");
+            Unwrapped(result.Error).Should().Contain("Updating submission product");
             result.Output.Should().Contain("\"FileUploadUrl\": \"https://azureblob.com/fileupload\"");
         }
 
@@ -377,7 +377,7 @@ namespace MSStore.CLI.UnitTests
                     "-"
                 ]);
 
-            result.Error.Should().Contain("Updating submission product");
+            Unwrapped(result.Error).Should().Contain("Updating submission product");
             result.Output.Should().Contain("\"FileUploadUrl\": \"https://azureblob.com/fileupload\"");
         }
 
@@ -408,7 +408,7 @@ namespace MSStore.CLI.UnitTests
                     FakeApps[0].Id!
                 ]);
 
-            result.Error.Should().Contain("Updating submission product");
+            Unwrapped(result.Error).Should().Contain("Updating submission product");
             result.Output.Should().Contain("\"FileUploadUrl\": \"https://azureblob.com/fileupload\"");
         }
 
@@ -422,7 +422,7 @@ namespace MSStore.CLI.UnitTests
                     FakeApps[0].Id!
                 ], 1);
 
-            result.Error.Should().Contain("No 'product' was provided.");
+            Unwrapped(result.Error).Should().Contain("No 'product' was provided.");
         }
 
         [TestMethod]
@@ -436,7 +436,7 @@ namespace MSStore.CLI.UnitTests
                     "this-file-does-not-exist.json"
                 ], 1);
 
-            result.Error.Should().Contain("is neither a JSON payload nor a path to an existing file");
+            Unwrapped(result.Error).Should().Contain("is neither a JSON payload nor a path to an existing file");
         }
 
         [TestMethod]
@@ -464,7 +464,7 @@ namespace MSStore.CLI.UnitTests
                     payloadFilePath
                 ], 1);
 
-            result.Error.Should().Contain("Use only one of them.");
+            Unwrapped(result.Error).Should().Contain("Use only one of them.");
         }
 
         [TestMethod]
@@ -507,7 +507,7 @@ namespace MSStore.CLI.UnitTests
                     It.IsAny<CancellationToken>()),
                 Times.Once);
 
-            result.Error.Should().Contain("Updating submission product");
+            Unwrapped(result.Error).Should().Contain("Updating submission product");
             result.Output.Should().Contain("\"FileUploadUrl\": \"https://azureblob.com/fileupload\"");
         }
 
@@ -535,7 +535,7 @@ namespace MSStore.CLI.UnitTests
 }"
                 ]);
 
-            result.Error.Should().Contain("Updating submission product");
+            Unwrapped(result.Error).Should().Contain("Updating submission product");
             result.Output.Should().Contain("\"FileUploadUrl\": \"https://azureblob.com/fileupload\"");
         }
 
@@ -567,7 +567,7 @@ namespace MSStore.CLI.UnitTests
                     payloadFilePath
                 ]);
 
-            result.Error.Should().Contain("Updating submission product");
+            Unwrapped(result.Error).Should().Contain("Updating submission product");
             result.Output.Should().Contain("\"FileUploadUrl\": \"https://azureblob.com/fileupload\"");
         }
 
@@ -593,7 +593,7 @@ namespace MSStore.CLI.UnitTests
                     FakeApps[0].Id!
                 ]);
 
-            result.Error.Should().Contain("Submission Committed with status");
+            Unwrapped(result.Error).Should().Contain("Submission Committed with status");
         }
 
         [TestMethod]
@@ -613,7 +613,7 @@ namespace MSStore.CLI.UnitTests
                     FakeApps[0].Id!
                 ]);
 
-            result.Error.Should().Contain("Submission commit success!");
+            Unwrapped(result.Error).Should().Contain("Submission commit success!");
         }
 
         [TestMethod]
@@ -637,8 +637,8 @@ namespace MSStore.CLI.UnitTests
 
             FakeConsole.Verify(x => x.YesNoConfirmationAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Once);
 
-            result.Error.Should().Contain($"Found Pending Submission with Id '{FakeApps[0].PendingApplicationSubmission!.Id}'");
-            result.Error.Should().Contain("Existing submission deleted!");
+            Unwrapped(result.Error).Should().Contain($"Found Pending Submission with Id '{FakeApps[0].PendingApplicationSubmission!.Id}'");
+            Unwrapped(result.Error).Should().Contain("Existing submission deleted!");
         }
     }
 }

--- a/MSStore.CLI/Commands/InitCommand.cs
+++ b/MSStore.CLI/Commands/InitCommand.cs
@@ -135,6 +135,7 @@ namespace MSStore.CLI.Commands
             Options.Add(ArchOption);
             Options.Add(VersionOption);
             Options.Add(PublishCommand.PackageRolloutPercentageOption);
+            Options.Add(PublishCommand.PriceIdOption);
             Options.Add(PublishCommand.UploadTimeoutOption);
         }
 
@@ -175,6 +176,7 @@ namespace MSStore.CLI.Commands
                 var flightId = parseResult.GetValue(PublishCommand.FlightIdOption);
                 var version = parseResult.GetValue(VersionOption);
                 var packageRolloutPercentage = parseResult.GetValue(PublishCommand.PackageRolloutPercentageOption);
+                var priceId = parseResult.GetValue(PublishCommand.PriceIdOption);
                 var uploadTimeout = parseResult.GetValue(PublishCommand.UploadTimeoutOption);
                 var output = parseResult.GetValue(OutputOption);
                 var arch = parseResult.GetValue(ArchOption);
@@ -363,7 +365,7 @@ namespace MSStore.CLI.Commands
                         return await _telemetryClient.TrackCommandEventAsync<Handler>(-5, props, ct);
                     }
 
-                    result = await projectPublisher.PublishAsync(pathOrUrl, app, flightId, outputDirectory, false, packageRolloutPercentage, uploadTimeout, storePackagedAPI, ct);
+                    result = await projectPublisher.PublishAsync(pathOrUrl, app, flightId, outputDirectory, false, packageRolloutPercentage, priceId, uploadTimeout, storePackagedAPI, ct);
                 }
 
                 return await _telemetryClient.TrackCommandEventAsync<Handler>(result, props, ct);

--- a/MSStore.CLI/Commands/PublishCommand.cs
+++ b/MSStore.CLI/Commands/PublishCommand.cs
@@ -12,6 +12,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.ApplicationInsights;
 using Microsoft.Extensions.Logging;
+using MSStore.API.Packaged.Models;
 using MSStore.CLI.Helpers;
 using MSStore.CLI.ProjectConfigurators;
 using MSStore.CLI.Services;
@@ -28,6 +29,7 @@ namespace MSStore.CLI.Commands
 
         internal static readonly Option<string> FlightIdOption;
         internal static readonly Option<float?> PackageRolloutPercentageOption;
+        internal static readonly Option<string?> PriceIdOption;
         internal static readonly Option<long> UploadTimeoutOption;
         private static readonly Option<DirectoryInfo?> InputDirectoryOption;
         private static readonly Option<string> AppIdOption;
@@ -64,6 +66,26 @@ namespace MSStore.CLI.Commands
                     {
                         return parsedPercentage;
                     }
+                }
+            };
+
+            PriceIdOption = new Option<string?>("--priceId", "-pid")
+            {
+                Description = "Specifies the base price tier to set on the submission, for example 'Tier1012', 'Free' or 'NotAvailable'. Only needed when the Store reports a base price the submission API will not accept back, which happens when the price is managed per market from Partner Center.",
+                CustomParser = result =>
+                {
+                    if (result.Tokens.Count == 0)
+                    {
+                        return null;
+                    }
+
+                    if (!PriceIds.TryNormalize(result.Tokens.Single().Value, out var normalized))
+                    {
+                        result.AddError("Invalid price id. The value must be 'Free', 'NotAvailable', or a tier such as 'Tier1012'.");
+                        return null;
+                    }
+
+                    return normalized;
                 }
             };
 
@@ -143,6 +165,7 @@ namespace MSStore.CLI.Commands
             Options.Add(NoCommitOption);
             Options.Add(FlightIdOption);
             Options.Add(PackageRolloutPercentageOption);
+            Options.Add(PriceIdOption);
             Options.Add(UploadTimeoutOption);
         }
 
@@ -165,6 +188,7 @@ namespace MSStore.CLI.Commands
                 var appId = parseResult.GetValue(AppIdOption);
                 var flightId = parseResult.GetValue(FlightIdOption);
                 var packageRolloutPercentage = parseResult.GetValue(PackageRolloutPercentageOption);
+                var priceId = parseResult.GetValue(PriceIdOption);
                 var inputDirectory = parseResult.GetValue(InputDirectoryOption);
                 var noCommit = parseResult.GetRequiredValue(NoCommitOption);
                 var uploadTimeout = parseResult.GetValue(UploadTimeoutOption);
@@ -214,7 +238,7 @@ namespace MSStore.CLI.Commands
                 }
 
                 return await _telemetryClient.TrackCommandEventAsync<Handler>(
-                    await projectPublisher.PublishAsync(pathOrUrl, app, flightId, inputDirectory, noCommit, packageRolloutPercentage, uploadTimeout, storePackagedAPI, ct), props, ct);
+                    await projectPublisher.PublishAsync(pathOrUrl, app, flightId, inputDirectory, noCommit, packageRolloutPercentage, priceId, uploadTimeout, storePackagedAPI, ct), props, ct);
             }
         }
     }

--- a/MSStore.CLI/Commands/PublishCommand.cs
+++ b/MSStore.CLI/Commands/PublishCommand.cs
@@ -71,7 +71,7 @@ namespace MSStore.CLI.Commands
 
             PriceIdOption = new Option<string?>("--priceId", "-pid")
             {
-                Description = "Specifies the base price tier to set on the submission, for example 'Tier1012', 'Free' or 'NotAvailable'. Only needed when the Store reports a base price the submission API will not accept back, which happens when the price is managed per market from Partner Center.",
+                Description = "Specifies the base price tier to set on the submission, for example 'Tier1012', 'Free' or 'NotAvailable'. Only needed when the Store reports a base price the submission API will not accept back, which happens when the price is managed per market from Partner Center. This sets a single base price for the product rather than preserving per-market prices, so consider '--noCommit' to review the submission before it goes live.",
                 CustomParser = result =>
                 {
                     if (result.Tokens.Count == 0)

--- a/MSStore.CLI/Commands/Submission/UpdateCommand.cs
+++ b/MSStore.CLI/Commands/Submission/UpdateCommand.cs
@@ -97,6 +97,7 @@ namespace MSStore.CLI.Commands.Submission
                 }
 
                 string? submissionId = application.PendingApplicationSubmission?.Id;
+                var draftWasCreatedHere = submissionId == null;
 
                 if (submissionId == null)
                 {
@@ -111,23 +112,29 @@ namespace MSStore.CLI.Commands.Submission
                     }
                 }
 
-                var currentSubmission = await storePackagedAPI.GetSubmissionAsync(application.Id, submissionId, ct);
-
                 // Only the payload actually being sent matters here. Blocking on the *current*
                 // submission would reject a perfectly good update whose JSON already carries a
                 // valid tier, which is the one way a per-market priced product can be updated.
                 var updatedPriceId = updateSubmission.Pricing?.PriceId;
                 if (updateSubmission.Pricing != null && !PriceIds.IsRoundTrippable(updatedPriceId))
                 {
-                    if (currentSubmission?.Id != null && application.PendingApplicationSubmission?.Id == null)
+                    // Clean up after ourselves, but never delete a draft the caller already had.
+                    if (draftWasCreatedHere)
                     {
-                        await storePackagedAPI.DeleteSubmissionAsync(application.Id, currentSubmission.Id, ct);
+                        await storePackagedAPI.DeleteSubmissionAsync(application.Id, submissionId, ct);
                     }
 
-                    ansiConsole.MarkupLine(string.IsNullOrWhiteSpace(updatedPriceId)
-                        ? "[red bold]The JSON you provided does not set 'Pricing.PriceId', which the submission API will not accept.[/]"
-                        : $"[red bold]The JSON you provided sets 'Pricing.PriceId' to '{updatedPriceId.EscapeMarkup()}', which the submission API will not accept.[/]");
-                    ansiConsole.MarkupLine("Sending it would reset the product to [bold]Free[/]. Set 'Pricing.PriceId' to a real tier (for example 'Tier1012'), 'Free', or 'NotAvailable' and try again.");
+                    if (string.IsNullOrWhiteSpace(updatedPriceId))
+                    {
+                        ansiConsole.MarkupLine("[red bold]The JSON you provided does not set 'Pricing.PriceId'.[/]");
+                        ansiConsole.MarkupLine("The submission API would accept that and silently reset the product to [bold]Free[/], so the update has been stopped instead.");
+                    }
+                    else
+                    {
+                        ansiConsole.MarkupLine($"[red bold]The JSON you provided sets 'Pricing.PriceId' to '{updatedPriceId.EscapeMarkup()}', which the submission API rejects.[/]");
+                    }
+
+                    ansiConsole.MarkupLine("Set 'Pricing.PriceId' to a real tier (for example 'Tier1012'), 'Free', or 'NotAvailable' and try again.");
                     return null;
                 }
 

--- a/MSStore.CLI/Commands/Submission/UpdateCommand.cs
+++ b/MSStore.CLI/Commands/Submission/UpdateCommand.cs
@@ -12,6 +12,7 @@ using Microsoft.Extensions.Logging;
 using MSStore.API;
 using MSStore.API.Models;
 using MSStore.API.Packaged;
+using MSStore.API.Packaged.Models;
 using MSStore.CLI.Helpers;
 using MSStore.CLI.Services;
 using Spectre.Console;
@@ -48,6 +49,14 @@ namespace MSStore.CLI.Commands.Submission
             private readonly IAnsiConsole _ansiConsole = ansiConsole ?? throw new ArgumentNullException(nameof(ansiConsole));
             private readonly TelemetryClient _telemetryClient = telemetryClient ?? throw new ArgumentNullException(nameof(telemetryClient));
 
+            /// <summary>
+            /// Updates a packaged submission.
+            /// </summary>
+            /// <returns>
+            /// The updated submission, or <c>null</c> when the update did not happen. A failure
+            /// must never be signalled with an <c>int</c>: the caller only checks for <c>null</c>,
+            /// so a boxed code would be reported as success and printed as the command's output.
+            /// </returns>
             public static async Task<object?> PackagedUpdateCommandAsync(IAnsiConsole ansiConsole, IStoreAPIFactory storeAPIFactory, string product, string productId, ILogger logger, CancellationToken ct)
             {
                 var updateSubmission = JsonSerializer.Deserialize(product, SourceGenerationContext.GetCustom().DevCenterSubmission);
@@ -84,7 +93,7 @@ namespace MSStore.CLI.Commands.Submission
 
                 if (storePackagedAPI == null || application == null || application?.Id == null)
                 {
-                    return 1;
+                    return null;
                 }
 
                 string? submissionId = application.PendingApplicationSubmission?.Id;
@@ -103,11 +112,21 @@ namespace MSStore.CLI.Commands.Submission
                 }
 
                 var currentSubmission = await storePackagedAPI.GetSubmissionAsync(application.Id, submissionId, ct);
-                if (currentSubmission?.Pricing != null && currentSubmission?.Pricing?.PriceId == "Base")
+
+                // Only the payload actually being sent matters here. Blocking on the *current*
+                // submission would reject a perfectly good update whose JSON already carries a
+                // valid tier, which is the one way a per-market priced product can be updated.
+                var updatedPriceId = updateSubmission.Pricing?.PriceId;
+                if (updateSubmission.Pricing != null && !PriceIds.IsRoundTrippable(updatedPriceId))
                 {
-                    await storePackagedAPI.DeleteSubmissionAsync(application.Id, submissionId: currentSubmission.Id!, ct);
-                    ansiConsole.MarkupLine("[red bold]App updates are supported only for Free products.[/]");
-                    return -1;
+                    if (currentSubmission?.Id != null && application.PendingApplicationSubmission?.Id == null)
+                    {
+                        await storePackagedAPI.DeleteSubmissionAsync(application.Id, currentSubmission.Id, ct);
+                    }
+
+                    ansiConsole.MarkupLine($"[red bold]The provided product has a base price of '{(updatedPriceId ?? "<empty>").EscapeMarkup()}', which the submission API will not accept.[/]");
+                    ansiConsole.MarkupLine("Sending it would reset the product to [bold]Free[/]. Set 'Pricing.PriceId' to a real tier (for example 'Tier1012'), 'Free', or 'NotAvailable' and try again.");
+                    return null;
                 }
 
                 return await ansiConsole.Status().StartAsync("Updating submission product", async ctx =>

--- a/MSStore.CLI/Commands/Submission/UpdateCommand.cs
+++ b/MSStore.CLI/Commands/Submission/UpdateCommand.cs
@@ -124,7 +124,9 @@ namespace MSStore.CLI.Commands.Submission
                         await storePackagedAPI.DeleteSubmissionAsync(application.Id, currentSubmission.Id, ct);
                     }
 
-                    ansiConsole.MarkupLine($"[red bold]The provided product has a base price of '{(updatedPriceId ?? "<empty>").EscapeMarkup()}', which the submission API will not accept.[/]");
+                    ansiConsole.MarkupLine(string.IsNullOrWhiteSpace(updatedPriceId)
+                        ? "[red bold]The JSON you provided does not set 'Pricing.PriceId', which the submission API will not accept.[/]"
+                        : $"[red bold]The JSON you provided sets 'Pricing.PriceId' to '{updatedPriceId.EscapeMarkup()}', which the submission API will not accept.[/]");
                     ansiConsole.MarkupLine("Sending it would reset the product to [bold]Free[/]. Set 'Pricing.PriceId' to a real tier (for example 'Tier1012'), 'Free', or 'NotAvailable' and try again.");
                     return null;
                 }

--- a/MSStore.CLI/Commands/Submission/UpdateCommand.cs
+++ b/MSStore.CLI/Commands/Submission/UpdateCommand.cs
@@ -116,7 +116,7 @@ namespace MSStore.CLI.Commands.Submission
                 // submission would reject a perfectly good update whose JSON already carries a
                 // valid tier, which is the one way a per-market priced product can be updated.
                 var updatedPriceId = updateSubmission.Pricing?.PriceId;
-                if (updateSubmission.Pricing != null && !PriceIds.IsRoundTrippable(updatedPriceId))
+                if (updateSubmission.Pricing == null || !PriceIds.IsRoundTrippable(updatedPriceId))
                 {
                     // Clean up after ourselves, but never delete a draft the caller already had.
                     if (draftWasCreatedHere)
@@ -124,7 +124,12 @@ namespace MSStore.CLI.Commands.Submission
                         await storePackagedAPI.DeleteSubmissionAsync(application.Id, submissionId, ct);
                     }
 
-                    if (string.IsNullOrWhiteSpace(updatedPriceId))
+                    if (updateSubmission.Pricing == null)
+                    {
+                        ansiConsole.MarkupLine("[red bold]The JSON you provided has no 'Pricing' object.[/]");
+                        ansiConsole.MarkupLine("An update replaces the whole submission, and the submission API rejects one that does not carry pricing.");
+                    }
+                    else if (string.IsNullOrWhiteSpace(updatedPriceId))
                     {
                         ansiConsole.MarkupLine("[red bold]The JSON you provided does not set 'Pricing.PriceId'.[/]");
                         ansiConsole.MarkupLine("The submission API would accept that and silently reset the product to [bold]Free[/], so the update has been stopped instead.");

--- a/MSStore.CLI/Helpers/IStorePackagedAPIExtensions.cs
+++ b/MSStore.CLI/Helpers/IStorePackagedAPIExtensions.cs
@@ -352,6 +352,7 @@ namespace MSStore.CLI.Helpers
             IEnumerable<FileInfo> input,
             bool noCommit,
             float? packageRolloutPercentage,
+            string? priceId,
             long uploadTimeout,
             IBrowserLauncher browserLauncher,
             IConsoleReader consoleReader,
@@ -493,10 +494,10 @@ namespace MSStore.CLI.Helpers
             DevCenterSubmission? devCenterSubmission = submission as DevCenterSubmission;
             DevCenterFlightSubmission? devCenterFlightSubmission = submission as DevCenterFlightSubmission;
 
-            if (devCenterSubmission?.Pricing != null && devCenterSubmission?.Pricing?.PriceId == "Base")
+            if (devCenterSubmission != null
+                && !TryPreservePricing(ansiConsole, devCenterSubmission, priceId, logger))
             {
                 await storePackagedAPI.DeleteSubmissionAsync(app.Id, submission.Id, ct);
-                ansiConsole.MarkupLine("[red bold]App updates are supported only for Free products.[/]");
                 return -1;
             }
 
@@ -781,6 +782,53 @@ namespace MSStore.CLI.Helpers
                 image.FileName = Path.Combine(listingKey, fileName);
                 return true;
             }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Makes sure publishing never changes the product's price.
+        /// </summary>
+        /// <remarks>
+        /// The submission API replaces the whole submission on update, so a complete and valid
+        /// <c>pricing</c> object has to be sent back. Only three things can go in
+        /// <see cref="Pricing.PriceId"/>, and for a product on the newer per-market pricing model
+        /// the API returns <see cref="PriceIds.Base"/>, which is not one of them:
+        /// <list type="bullet">
+        /// <item><description><see cref="PriceIds.Base"/> - rejected with <c>'Base' is not a valid PriceId for base price.</c></description></item>
+        /// <item><description>an empty value - accepted with <c>200 OK</c>, and the product silently becomes free.</description></item>
+        /// <item><description>omitting <c>pricing</c> - rejected with <c>Pricing data was not provided in the request.</c></description></item>
+        /// </list>
+        /// Any other price id (<c>Free</c>, <c>NotAvailable</c>, <c>Tier1012</c>, ...) round-trips
+        /// unchanged, so paid products publish fine as long as we leave the value alone.
+        /// </remarks>
+        /// <returns><c>false</c> when the price cannot be preserved and publishing must stop.</returns>
+        internal static bool TryPreservePricing(IAnsiConsole ansiConsole, DevCenterSubmission submission, string? priceIdOverride, ILogger logger)
+        {
+            if (priceIdOverride != null)
+            {
+                logger.LogInformation("Overriding PriceId '{OriginalPriceId}' with '{PriceIdOverride}'.", submission.Pricing?.PriceId, priceIdOverride);
+                ansiConsole.MarkupLine($"Setting the base price to [green]{priceIdOverride.EscapeMarkup()}[/].");
+
+                // A product whose price is managed per market can come back without any pricing
+                // at all, and the API rejects an update that omits it.
+                submission.Pricing ??= new Pricing();
+                submission.Pricing.PriceId = priceIdOverride;
+                return true;
+            }
+
+            if (submission.Pricing == null || PriceIds.IsRoundTrippable(submission.Pricing.PriceId))
+            {
+                return true;
+            }
+
+            var priceId = submission.Pricing.PriceId;
+            logger.LogError("Cannot preserve the product's price. The API returned PriceId '{PriceId}', which it does not accept back on update.", priceId);
+
+            ansiConsole.MarkupLine("[red bold]Could not preserve this product's price.[/]");
+            ansiConsole.MarkupLine($"The Store returned a base price of [yellow]'{(priceId ?? "<empty>").EscapeMarkup()}'[/], which the submission API refuses on update. This happens when the price is managed per market from Partner Center.");
+            ansiConsole.MarkupLine("Publishing would reset the product to [bold]Free[/], so it has been stopped instead.");
+            ansiConsole.MarkupLine("Re-run with [green]--priceId[/] to state the base price explicitly (for example [green]--priceId Tier1012[/]), or publish this submission from Partner Center.");
 
             return false;
         }

--- a/MSStore.CLI/Helpers/IStorePackagedAPIExtensions.cs
+++ b/MSStore.CLI/Helpers/IStorePackagedAPIExtensions.cs
@@ -824,16 +824,21 @@ namespace MSStore.CLI.Helpers
                 return true;
             }
 
-            if (submission.Pricing == null || PriceIds.IsRoundTrippable(submission.Pricing.PriceId))
+            if (submission.Pricing != null && PriceIds.IsRoundTrippable(submission.Pricing.PriceId))
             {
                 return true;
             }
 
-            var priceId = submission.Pricing.PriceId;
-            logger.LogError("Cannot preserve the product's price. The API returned PriceId '{PriceId}', which it does not accept back on update.", priceId);
+            // A missing pricing object is just as unsendable as a bad price id - the API answers
+            // "Pricing data was not provided in the request." - so stop here with usable guidance
+            // rather than letting the update fail with a raw 400 further down.
+            var priceId = submission.Pricing?.PriceId;
+            logger.LogError("Cannot preserve the product's price. The submission has PriceId '{PriceId}', which the API does not accept on update.", priceId);
 
             ansiConsole.MarkupLine("[red bold]Could not preserve this product's price.[/]");
-            ansiConsole.MarkupLine($"The Store returned a base price of [yellow]'{(priceId ?? "<empty>").EscapeMarkup()}'[/], which the submission API refuses on update. This happens when the price is managed per market from Partner Center.");
+            ansiConsole.MarkupLine(submission.Pricing == null
+                ? "The Store returned no pricing for this product, and the submission API rejects an update that does not carry one."
+                : $"The Store returned a base price of [yellow]'{(priceId ?? "<empty>").EscapeMarkup()}'[/], which the submission API refuses on update. This happens when the price is managed per market from Partner Center.");
             ansiConsole.MarkupLine("Publishing would reset the product to [bold]Free[/], so it has been stopped instead.");
             ansiConsole.MarkupLine("Re-run with [green]--priceId[/] to state the base price explicitly (for example [green]--priceId Tier1012[/]), or publish this submission from Partner Center.");
 

--- a/MSStore.CLI/Helpers/IStorePackagedAPIExtensions.cs
+++ b/MSStore.CLI/Helpers/IStorePackagedAPIExtensions.cs
@@ -829,17 +829,28 @@ namespace MSStore.CLI.Helpers
                 return true;
             }
 
-            // A missing pricing object is just as unsendable as a bad price id - the API answers
-            // "Pricing data was not provided in the request." - so stop here with usable guidance
-            // rather than letting the update fail with a raw 400 further down.
+            // Neither a missing pricing object nor an unusable price id can be sent, but they fail
+            // differently: the first two are rejected outright, an empty price id is accepted and
+            // silently turns the product free. Stop for all three, and say which one it is.
             var priceId = submission.Pricing?.PriceId;
-            logger.LogError("Cannot preserve the product's price. The submission has PriceId '{PriceId}', which the API does not accept on update.", priceId);
+            logger.LogError("Cannot preserve the product's price. The submission has PriceId '{PriceId}', which cannot be sent back.", priceId);
 
             ansiConsole.MarkupLine("[red bold]Could not preserve this product's price.[/]");
-            ansiConsole.MarkupLine(submission.Pricing == null
-                ? "The Store returned no pricing for this product, and the submission API rejects an update that does not carry one."
-                : $"The Store returned a base price of [yellow]'{(priceId ?? "<empty>").EscapeMarkup()}'[/], which the submission API refuses on update. This happens when the price is managed per market from Partner Center.");
-            ansiConsole.MarkupLine("Publishing would reset the product to [bold]Free[/], so it has been stopped instead.");
+
+            if (submission.Pricing == null)
+            {
+                ansiConsole.MarkupLine("The Store returned no pricing for this product, and the submission API rejects an update that does not carry one.");
+            }
+            else if (string.IsNullOrWhiteSpace(priceId))
+            {
+                ansiConsole.MarkupLine("The Store returned no base price for this product. The submission API would accept that and silently reset the product to [bold]Free[/].");
+            }
+            else
+            {
+                ansiConsole.MarkupLine($"The Store returned a base price of [yellow]'{priceId.EscapeMarkup()}'[/], which the submission API rejects on update. This happens when the price is managed per market from Partner Center.");
+            }
+
+            ansiConsole.MarkupLine("Publishing has been stopped so the price is left as it is.");
             ansiConsole.MarkupLine("Re-run with [green]--priceId[/] to state the base price explicitly (for example [green]--priceId Tier1012[/]), or publish this submission from Partner Center.");
 
             return false;

--- a/MSStore.CLI/Helpers/IStorePackagedAPIExtensions.cs
+++ b/MSStore.CLI/Helpers/IStorePackagedAPIExtensions.cs
@@ -833,20 +833,22 @@ namespace MSStore.CLI.Helpers
             // differently: the first two are rejected outright, an empty price id is accepted and
             // silently turns the product free. Stop for all three, and say which one it is.
             var priceId = submission.Pricing?.PriceId;
-            logger.LogError("Cannot preserve the product's price. The submission has PriceId '{PriceId}', which cannot be sent back.", priceId);
 
             ansiConsole.MarkupLine("[red bold]Could not preserve this product's price.[/]");
 
             if (submission.Pricing == null)
             {
+                logger.LogError("Cannot preserve the product's price: the submission carries no pricing, which the API rejects on update.");
                 ansiConsole.MarkupLine("The Store returned no pricing for this product, and the submission API rejects an update that does not carry one.");
             }
             else if (string.IsNullOrWhiteSpace(priceId))
             {
+                logger.LogError("Cannot preserve the product's price: the submission has no PriceId, and sending that resets the product to free.");
                 ansiConsole.MarkupLine("The Store returned no base price for this product. The submission API would accept that and silently reset the product to [bold]Free[/].");
             }
             else
             {
+                logger.LogError("Cannot preserve the product's price: the submission has PriceId '{PriceId}', which the API rejects on update.", priceId);
                 ansiConsole.MarkupLine($"The Store returned a base price of [yellow]'{priceId.EscapeMarkup()}'[/], which the submission API rejects on update. This happens when the price is managed per market from Partner Center.");
             }
 

--- a/MSStore.CLI/Helpers/IStorePackagedAPIExtensions.cs
+++ b/MSStore.CLI/Helpers/IStorePackagedAPIExtensions.cs
@@ -790,17 +790,24 @@ namespace MSStore.CLI.Helpers
         /// Makes sure publishing never changes the product's price.
         /// </summary>
         /// <remarks>
-        /// The submission API replaces the whole submission on update, so a complete and valid
-        /// <c>pricing</c> object has to be sent back. Only three things can go in
-        /// <see cref="Pricing.PriceId"/>, and for a product on the newer per-market pricing model
-        /// the API returns <see cref="PriceIds.Base"/>, which is not one of them:
+        /// The submission API replaces the whole submission on update - there are no patch
+        /// semantics, so anything the request does not state explicitly is reset to its default.
+        /// A complete and valid <c>pricing</c> object therefore has to be sent back every time,
+        /// even when publishing has no interest in the price. For a product on the newer
+        /// per-market pricing model the API returns <see cref="PriceIds.Base"/>, and none of the
+        /// ways of expressing "leave the price alone" work:
         /// <list type="bullet">
         /// <item><description><see cref="PriceIds.Base"/> - rejected with <c>'Base' is not a valid PriceId for base price.</c></description></item>
-        /// <item><description>an empty value - accepted with <c>200 OK</c>, and the product silently becomes free.</description></item>
-        /// <item><description>omitting <c>pricing</c> - rejected with <c>Pricing data was not provided in the request.</c></description></item>
+        /// <item><description>an empty value, the property removed, or an empty pricing object - all accepted with <c>200 OK</c>, and the product silently becomes free.</description></item>
+        /// <item><description>a null or omitted <c>pricing</c> - rejected with <c>Pricing data was not provided in the request.</c></description></item>
         /// </list>
+        /// Nor can the real price be looked up: it is absent from the application resource, the
+        /// newer submission API does not know packaged products, and no API exposes the price
+        /// tier table. So for those products the price can only come from the caller.
+        /// <para>
         /// Any other price id (<c>Free</c>, <c>NotAvailable</c>, <c>Tier1012</c>, ...) round-trips
         /// unchanged, so paid products publish fine as long as we leave the value alone.
+        /// </para>
         /// </remarks>
         /// <returns><c>false</c> when the price cannot be preserved and publishing must stop.</returns>
         internal static bool TryPreservePricing(IAnsiConsole ansiConsole, DevCenterSubmission submission, string? priceIdOverride, ILogger logger)

--- a/MSStore.CLI/Helpers/IStorePackagedAPIExtensions.cs
+++ b/MSStore.CLI/Helpers/IStorePackagedAPIExtensions.cs
@@ -854,6 +854,7 @@ namespace MSStore.CLI.Helpers
 
             ansiConsole.MarkupLine("Publishing has been stopped so the price is left as it is.");
             ansiConsole.MarkupLine("Re-run with [green]--priceId[/] to state the base price explicitly (for example [green]--priceId Tier1012[/]), or publish this submission from Partner Center.");
+            ansiConsole.MarkupLine("[yellow]--priceId[/] sets a single base price for the product rather than preserving per-market prices, so publishing from Partner Center is the safer option when this product is priced per market.");
 
             return false;
         }

--- a/MSStore.CLI/ProjectConfigurators/ElectronProjectConfigurator.cs
+++ b/MSStore.CLI/ProjectConfigurators/ElectronProjectConfigurator.cs
@@ -406,7 +406,7 @@ namespace MSStore.CLI.ProjectConfigurators
             _electronManifest ??= await _electronManifestManager.LoadAsync(fileInfo, ct);
         }
 
-        public override async Task<int> PublishAsync(string pathOrUrl, DevCenterApplication? app, string? flightId, DirectoryInfo? inputDirectory, bool noCommit, float? packageRolloutPercentage, long uploadTimeout, IStorePackagedAPI storePackagedAPI, CancellationToken ct)
+        public override async Task<int> PublishAsync(string pathOrUrl, DevCenterApplication? app, string? flightId, DirectoryInfo? inputDirectory, bool noCommit, float? packageRolloutPercentage, string? priceId, long uploadTimeout, IStorePackagedAPI storePackagedAPI, CancellationToken ct)
         {
             if (_electronManifest == null)
             {
@@ -414,7 +414,7 @@ namespace MSStore.CLI.ProjectConfigurators
                 await EnsureElectronManifestAsync(manifestFile, ct);
             }
 
-            return await base.PublishAsync(pathOrUrl, app, flightId, inputDirectory, noCommit, packageRolloutPercentage, uploadTimeout, storePackagedAPI, ct);
+            return await base.PublishAsync(pathOrUrl, app, flightId, inputDirectory, noCommit, packageRolloutPercentage, priceId, uploadTimeout, storePackagedAPI, ct);
         }
     }
 }

--- a/MSStore.CLI/ProjectConfigurators/FileProjectConfigurator.cs
+++ b/MSStore.CLI/ProjectConfigurators/FileProjectConfigurator.cs
@@ -138,7 +138,7 @@ namespace MSStore.CLI.ProjectConfigurators
             return Task.FromResult<(string, List<SubmissionImage>)>((description, images));
         }
 
-        public virtual async Task<int> PublishAsync(string pathOrUrl, DevCenterApplication? app, string? flightId, DirectoryInfo? inputDirectory, bool noCommit, float? packageRolloutPercentage, long uploadTimeout, IStorePackagedAPI storePackagedAPI, CancellationToken ct)
+        public virtual async Task<int> PublishAsync(string pathOrUrl, DevCenterApplication? app, string? flightId, DirectoryInfo? inputDirectory, bool noCommit, float? packageRolloutPercentage, string? priceId, long uploadTimeout, IStorePackagedAPI storePackagedAPI, CancellationToken ct)
         {
             var (projectRootPath, projectFile) = GetInfo(pathOrUrl);
 
@@ -181,7 +181,7 @@ namespace MSStore.CLI.ProjectConfigurators
 
             Logger.LogInformation("Trying to publish these {FileCount} files: {FileNames}", packageFiles.Count(), string.Join(", ", packageFiles.Select(f => $"'{f.FullName}'")));
 
-            return await storePackagedAPI.PublishAsync(ErrorAnsiConsole, app, flightId, GetFirstSubmissionDataAsync, AllowTargetFutureDeviceFamilies, output, packageFiles, noCommit, packageRolloutPercentage, uploadTimeout, _browserLauncher, _consoleReader, _zipFileManager, _fileDownloader, _azureBlobManager, _environmentInformationService, _logger, ct);
+            return await storePackagedAPI.PublishAsync(ErrorAnsiConsole, app, flightId, GetFirstSubmissionDataAsync, AllowTargetFutureDeviceFamilies, output, packageFiles, noCommit, packageRolloutPercentage, priceId, uploadTimeout, _browserLauncher, _consoleReader, _zipFileManager, _fileDownloader, _azureBlobManager, _environmentInformationService, _logger, ct);
         }
 
         protected virtual DirectoryInfo GetInputDirectory(DirectoryInfo projectRootPath)

--- a/MSStore.CLI/ProjectConfigurators/IProjectPublisher.cs
+++ b/MSStore.CLI/ProjectConfigurators/IProjectPublisher.cs
@@ -17,6 +17,6 @@ namespace MSStore.CLI.ProjectConfigurators
         SearchOption PackageFilesSearchOption { get; }
         AllowTargetFutureDeviceFamily[] AllowTargetFutureDeviceFamilies { get; }
         Task<bool> CanPublishAsync(string pathOrUrl, CancellationToken ct);
-        Task<int> PublishAsync(string pathOrUrl, DevCenterApplication? app, string? flightId, DirectoryInfo? inputDirectory, bool noCommit, float? packageRolloutPercentage, long uploadTimeout, IStorePackagedAPI storePackagedAPI, CancellationToken ct);
+        Task<int> PublishAsync(string pathOrUrl, DevCenterApplication? app, string? flightId, DirectoryInfo? inputDirectory, bool noCommit, float? packageRolloutPercentage, string? priceId, long uploadTimeout, IStorePackagedAPI storePackagedAPI, CancellationToken ct);
     }
 }

--- a/MSStore.CLI/ProjectConfigurators/MSIXProjectPublisher.cs
+++ b/MSStore.CLI/ProjectConfigurators/MSIXProjectPublisher.cs
@@ -94,7 +94,7 @@ namespace MSStore.CLI.ProjectConfigurators
             return Task.FromResult(_appXManifestManager.GetAppId(appxManifest));
         }
 
-        public async Task<int> PublishAsync(string pathOrUrl, DevCenterApplication? app, string? flightId, DirectoryInfo? inputDirectory, bool noCommit, float? packageRolloutPercentage, long uploadTimeout, IStorePackagedAPI storePackagedAPI, CancellationToken ct)
+        public async Task<int> PublishAsync(string pathOrUrl, DevCenterApplication? app, string? flightId, DirectoryInfo? inputDirectory, bool noCommit, float? packageRolloutPercentage, string? priceId, long uploadTimeout, IStorePackagedAPI storePackagedAPI, CancellationToken ct)
         {
             var msix = new FileInfo(pathOrUrl);
 
@@ -131,7 +131,7 @@ namespace MSStore.CLI.ProjectConfigurators
 
             _logger.LogInformation("Trying to publish these {FileCount} files: {FileNames}", packageFiles.Count, string.Join(", ", packageFiles.Select(f => $"'{f.FullName}'")));
 
-            return await storePackagedAPI.PublishAsync(_ansiConsole, _app, flightId, GetFirstSubmissionDataAsync, AllowTargetFutureDeviceFamilies, output, packageFiles, noCommit, packageRolloutPercentage, uploadTimeout, _browserLauncher, _consoleReader, _zipFileManager, _fileDownloader, _azureBlobManager, _environmentInformationService, _logger, ct);
+            return await storePackagedAPI.PublishAsync(_ansiConsole, _app, flightId, GetFirstSubmissionDataAsync, AllowTargetFutureDeviceFamilies, output, packageFiles, noCommit, packageRolloutPercentage, priceId, uploadTimeout, _browserLauncher, _consoleReader, _zipFileManager, _fileDownloader, _azureBlobManager, _environmentInformationService, _logger, ct);
         }
 
         private Task<(string Description, List<SubmissionImage> Images)> GetFirstSubmissionDataAsync(string listingLanguage, CancellationToken ct)

--- a/MSStore.CLI/ProjectConfigurators/PWAProjectConfigurator.cs
+++ b/MSStore.CLI/ProjectConfigurators/PWAProjectConfigurator.cs
@@ -317,7 +317,7 @@ namespace MSStore.CLI.ProjectConfigurators
             return Task.FromResult((0, (DirectoryInfo?)new DirectoryInfo(pathOrUrl)));
         }
 
-        public async Task<int> PublishAsync(string pathOrUrl, DevCenterApplication? app, string? flightId, DirectoryInfo? inputDirectory, bool noCommit, float? packageRolloutPercentage, long uploadTimeout, IStorePackagedAPI storePackagedAPI, CancellationToken ct)
+        public async Task<int> PublishAsync(string pathOrUrl, DevCenterApplication? app, string? flightId, DirectoryInfo? inputDirectory, bool noCommit, float? packageRolloutPercentage, string? priceId, long uploadTimeout, IStorePackagedAPI storePackagedAPI, CancellationToken ct)
         {
             Uri? uri = GetUri(pathOrUrl);
 
@@ -391,6 +391,7 @@ namespace MSStore.CLI.ProjectConfigurators
                 packageFiles,
                 noCommit,
                 packageRolloutPercentage,
+                priceId,
                 uploadTimeout,
                 _browserLauncher,
                 _consoleReader,


### PR DESCRIPTION
## Why

`msstore publish` was resetting paid apps to USD 0.00 (#112).

The submission API replaces the **whole** submission on update, so publish has to send a complete, valid `pricing` object back even when it has no interest in the price. There are no patch semantics: anything the request does not state explicitly is reset to its default, and that default is free.

Every behaviour below was measured against the live DevCenter API using a throwaway submission draft that was never committed:

| Sent | Status | Result |
| --- | --- | --- |
| `priceId: "Free"` / `"Tier96"` / `"Tier1012"` / `"Tier1424"` | 200 | preserved |
| `priceId: "Base"` | 400 | `'Base' is not a valid PriceId for base price.` |
| `priceId: null` | **200 OK** | **silently becomes Free** |
| `priceId` property removed | **200 OK** | **silently becomes Free** |
| `pricing: {}` | **200 OK** | **silently becomes Free** |
| `pricing: null` or omitted | 400 | `Pricing data was not provided in the request.` |

`0b4b0bc` sent an empty `PriceId` whenever `IsAdvancedPricingModel` was set, which is the silent case: the API returns 200 and wipes the price, with no error to notice.

That condition was wrong on its own terms too. `isAdvancedPricingModel` is documented as read-only and only says which tier range a dashboard offers. Live data shows it is unreliable: on the test account it is `true` for *free* apps and `false` for others, it flipped `true` to `false` after a PUT that echoed it back unchanged, and both documented tier ranges were accepted on the same product. It must not gate any logic.

`51c1bc4` then stopped the data loss by refusing to publish anything whose `PriceId` is `Base`, reporting "App updates are supported only for Free products". That message is not accurate. A product with a real tier round-trips unchanged and publishes fine; only the `Base` sentinel cannot be sent back. The practical effect was that paid products could not publish at all.

## What this does

Publish now leaves any round-trippable price alone, so ordinary paid products publish normally again. It never sends an empty `PriceId`.

For products where the API hands back `Base`, the real price cannot be recovered from anywhere: it is absent from the application resource, the newer submission API returns 404 for packaged products, and no API exposes the price tier table. So the price can only come from the caller, and a new `--priceId` / `-pid` option on `publish` and `init` states it explicitly. When neither is possible, publishing still stops rather than resetting the price, but now explains why and how to proceed.

Tier numbers are deliberately not range checked. Both documented ranges were accepted on the same product and `isAdvancedPricingModel` cannot distinguish them, so the service decides.

`submission update` was rejecting based on the price of the *current* submission, which blocked the one payload that can actually update such a product: one carrying a real tier. It now validates the payload being sent.

## Worth a closer look

- **A latent bug is fixed here too.** `PackagedUpdateCommandAsync` signalled failure by returning a boxed `int`, but the caller only checks for `null`, so those paths were reported as success and printed the code as the command's output. The pre-existing "only Free products" path had this defect as well.
- **`--priceId` only ever surfaces for products the API hands back as `Base`**, which are currently blocked outright. Free and normally priced paid products never see it. Happy to drop the option and simply leave those users to Partner Center if that is preferred; the rest of the fix stands either way.
- **The serializer is guarded.** Adding `JsonIgnore(WhenWritingNull)` to `Pricing.PriceId` looks like a tidy-up but would silently reintroduce this bug, since omitting the property wipes the price exactly like sending it as null. There is a test for that.
- New tests assert on the **outgoing PUT payload**, which is the only way to catch a regression the API answers with 200 OK.

## Validation

225 tests, 0 build warnings. The two `PublishCommandFor{WinUI,Maui}AppsShouldCallMSBuildIfWindows` failures on `net10.0` are pre-existing and unrelated, confirmed by stashing this change and re-running on a clean tree; the Windows target framework is 225/0.

Also exercised end to end with the built CLI against the live API on a real app, using a throwaway draft that was deleted afterwards:

- payload with `PriceId: "Base"` - blocked, exit -1, no write
- payload with `Pricing` but no `PriceId` - blocked, exit -1, no write
- full submission carrying `Tier1012` - accepted, and an independent server side read confirmed `priceId = Tier1012`

One gap worth stating plainly: I could not reproduce a product that the API actually returns `Base` for, because that requires the per market pricing flow in the Partner Center web UI and appears to be effectively one way. The API side of that case is proven (400 on `Base`) and the payload side is proven end to end, but the publish path reading `Base` back from a real product is covered only by unit tests.

Fixes: #112