### PR TITLE
Add bug report and feature request issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,97 @@
+name: Bug report
+description: Report unexpected behavior or a crash in the Microsoft Store Developer CLI.
+title: "[Bug]: "
+labels:
+  - bug
+type: Bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for helping improve MSStore CLI.
+
+        Please search [existing issues](https://github.com/microsoft/msstore-cli/issues) before filing a new one.
+
+        **Do not paste secrets** (client secrets, certificates, tokens, or Partner Center credentials).
+        Security vulnerabilities must be reported privately — see [SECURITY.md](https://github.com/microsoft/msstore-cli/blob/main/SECURITY.md).
+  - type: dropdown
+    id: area
+    attributes:
+      label: Relevant command / area
+      description: Where did the problem show up?
+      multiple: true
+      options:
+        - init
+        - info
+        - reconfigure
+        - settings
+        - package
+        - publish
+        - apps
+        - submission
+        - flights
+        - other / not sure
+    validations:
+      required: true
+  - type: textarea
+    id: description
+    attributes:
+      label: Describe the bug
+      description: A clear and concise summary of what went wrong.
+    validations:
+      required: true
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce
+      description: Minimal steps someone else can follow.
+      placeholder: |
+        1.
+        2.
+        3.
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: What did you expect to happen?
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+      description: What happened instead? Include error messages.
+    validations:
+      required: true
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Output of `msstore --version` plus OS and how you installed the CLI.
+      render: shell
+      placeholder: |
+        msstore --version:
+        OS (Windows / macOS / Linux + version):
+        Install method (WinGet / dotnet tool / GitHub release / built from source):
+        Project type if relevant (MSIX, MSI/EXE, Flutter, PWA, Electron, …):
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs
+      description: Optional. Re-run with `--verbose` and paste the relevant output. Redact secrets.
+      render: shell
+    validations:
+      required: false
+  - type: checkboxes
+    id: search
+    attributes:
+      label: Checklist
+      options:
+        - label: I searched existing issues and this is not a duplicate
+          required: true
+        - label: This is not a security vulnerability (those go to MSRC, not GitHub)
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Documentation
+    url: https://aka.ms/msstoredevcli/docs
+    about: Commands, installation, and CI/CD setup
+  - name: Questions and usage help
+    url: https://github.com/microsoft/msstore-cli/discussions
+    about: Ask how to use the CLI (not a bug or feature request)
+  - name: Report a security vulnerability
+    url: https://aka.ms/opensource/security/create-report
+    about: Do not file security issues on GitHub — report them privately to MSRC

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,67 @@
+name: Feature request
+description: Suggest a new command, option, or improvement.
+title: "[Feature]: "
+labels:
+  - enhancement
+type: Feature
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for the idea. Please search [existing issues](https://github.com/microsoft/msstore-cli/issues) first, and add a 👍 on a duplicate instead of opening another request.
+  - type: dropdown
+    id: area
+    attributes:
+      label: Relevant command / area
+      description: What part of the CLI would this change?
+      multiple: true
+      options:
+        - init
+        - info
+        - reconfigure
+        - settings
+        - package
+        - publish
+        - apps
+        - submission
+        - flights
+        - docs / developer experience
+        - other / not sure
+    validations:
+      required: true
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What problem are you trying to solve? Who is affected?
+      placeholder: As a developer publishing to the Store, I need …
+    validations:
+      required: true
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed solution
+      description: What would you like the CLI to do? Include example commands if you can.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Other approaches you tried or considered (Partner Center UI, scripts, another tool).
+    validations:
+      required: false
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional context
+      description: Docs links, screenshots, or related issues.
+    validations:
+      required: false
+  - type: checkboxes
+    id: search
+    attributes:
+      label: Checklist
+      options:
+        - label: I searched existing issues and this is not a duplicate
+          required: true

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -5,14 +5,15 @@
 This project uses [GitHub Issues][gh-issue] to [track bugs][gh-bug] and [feature requests][gh-feature]. Please search the existing issues before filing new issues to avoid duplicates.  For new issues, file your bug or 
 feature request as a new Issue.
 
-For help and questions about using this project, please look at our [Wiki][wiki] for using the Microsoft Store Developer CLI and our [Contributor's Guide][contributor] if you want to work on MSStoreCLI.
+For help and questions about using this project, please look at our [documentation][docs] or ask in [Discussions][discussions]. See our [Contributor's Guide][contributor] if you want to work on MSStoreCLI.
 
 ## Microsoft Support Policy
 
 Support for the Microsoft Store Developer CLI is limited to the resources listed above.
 
 [gh-issue]: https://github.com/microsoft/msstore-cli/issues/new/choose
-[gh-bug]: https://github.com/microsoft/msstore-cli/issues/new?assignees=&labels=Issue-Bug&template=bug_report.md&title=
-[gh-feature]: https://github.com/microsoft/msstore-cli/issues/new?assignees=&labels=&template=feature_request.md&title=
-[wiki]: https://github.com/microsoft/msstore-cli/wiki
+[gh-bug]: https://github.com/microsoft/msstore-cli/issues/new?assignees=&labels=bug&template=bug_report.yml&title=
+[gh-feature]: https://github.com/microsoft/msstore-cli/issues/new?assignees=&labels=enhancement&template=feature_request.yml&title=
+[docs]: https://aka.ms/msstoredevcli/docs
+[discussions]: https://github.com/microsoft/msstore-cli/discussions
 [contributor]: https://github.com/microsoft/msstore-cli/blob/main/CONTRIBUTING.md


### PR DESCRIPTION
## Why

The repo had no issue templates at all, so every new issue arrived as free-form text and triage had to ask for the CLI version, OS, and repro steps by hand. `SUPPORT.md` also linked to `bug_report.md` and `feature_request.md`, neither of which ever existed in the repo — both links landed on a blank issue.

## What

**New — `.github/ISSUE_TEMPLATE/`**

- `bug_report.yml` — YAML issue form titled `[Bug]: `, labeled `bug`, `type: Bug`. Collects affected command/area (multi-select: init, package, publish, submission, flights, …), description, repro steps, expected vs actual behavior, and environment (`msstore --version`, OS, install method), plus optional `--verbose` logs. Header warns against pasting secrets and points to `SECURITY.md`.
- `feature_request.yml` — titled `[Feature]: `, labeled `enhancement`, `type: Feature`. Collects area, problem, proposed solution, and optional alternatives/context.
- `config.yml` — disables blank issues and adds contact links for docs, Discussions, and MSRC.

**Modified — `SUPPORT.md`**

- Bug and feature links now point at the templates that actually exist.
- Replaced the `[wiki]` reference with `[docs]` and `[discussions]`. The wiki is enabled but has **no pages**, so `…/wiki` redirects to the repo root; Discussions has 9 live threads and is the real Q&A venue.

## Verified against the live repo

- Labels `bug` and `enhancement` exist (the initial draft used `Issue-Bug`/`Issue-Feature`, which don't exist here and would have been silently dropped).
- Issue types `Bug` and `Feature` are enabled on the `microsoft` org.
- All three contact-link URLs return 200.

## Note

`config.yml` includes an explicit MSRC contact link. This duplicates the "Report a security vulnerability" row GitHub generates automatically from `SECURITY.md`, and none of the Microsoft repos I checked (terminal, PowerToys, winget-cli, vscode, WindowsAppSDK, playwright, dotnet/sdk) hand-roll one. Kept deliberately so the MSRC form is one click away rather than two — happy to drop it if reviewers prefer the house style.

Separately: private vulnerability reporting is currently disabled on this repo. Enabling it is a repo setting, not a file change, but it would give reporters a proper in-GitHub button.